### PR TITLE
Timed voting smart contract

### DIFF
--- a/contracts/ownership/TimedVote.sol
+++ b/contracts/ownership/TimedVote.sol
@@ -193,7 +193,7 @@ contract TimedVote {
    * @notice
    * A commitment is locked if its age is within the vote duration.
    * @dev
-   * Assumes the specified account has an active commitment.
+   * Assumes active commitment.
    * @param _account - Account owning commitment to check.
    * @return locked - Whether commitment of the specified account is locked.
    */
@@ -210,7 +210,7 @@ contract TimedVote {
    * @notice
    * A proposal is open for voting if its age is within the vote duration.
    * @dev
-   * Assumes a proposal with the specified identifier exists.
+   * Assumes extant proposal.
    * @param _proposalID - Identifier of proposal to check.
    * @return open - Whether proposal with the specified identifier is open.
    */
@@ -241,7 +241,7 @@ contract TimedVote {
   /**
    * Require proposal closed
    * @dev
-   * Throws if named proposal is open. Assumes proposal exists.
+   * Throws if named proposal is open. Assumes extant proposal.
    * @param _proposalID - Identifier of proposal that must be closed.
    */
   modifier onlyClosed(bytes32 _proposalID) {
@@ -297,7 +297,7 @@ contract TimedVote {
   /**
    * Require proposal open
    * @dev
-   * Throws if named proposal is closed. Assumes proposal exists.
+   * Throws if named proposal is closed. Assumes extant proposal.
    * @param _proposalID - Identifier of proposal that must be open.
    */
   modifier onlyOpen(bytes32 _proposalID) {
@@ -340,7 +340,7 @@ contract TimedVote {
    * Require commitment unlocked
    * @dev
    * Throws if the commitment of the specified account is locked.
-   * Assumes the account has an active commitment.
+   * Assumes active commitment.
    * @param _account - Account owning commitment that must be unlocked.
    */
   modifier onlyUnlocked(address _account) {

--- a/contracts/ownership/TimedVote.sol
+++ b/contracts/ownership/TimedVote.sol
@@ -206,6 +206,20 @@ contract TimedVote {
   }
 
   /**
+   * Get proposal age
+   * @dev
+   * Assumes extant proposal.
+   * @param _proposalID - Identifier of proposal to get age of.
+   * @return age - Proposal age.
+   */
+  function proposalAge(bytes32 _proposalID)
+  internal
+  view
+  returns (uint256 age) {
+    return time().sub(proposals[_proposalID].start);
+  }
+
+  /**
    * Check proposal open
    * @notice
    * A proposal is open for voting until vote duration has elapsed.

--- a/contracts/ownership/TimedVote.sol
+++ b/contracts/ownership/TimedVote.sol
@@ -191,7 +191,7 @@ contract TimedVote {
   /**
    * Check commitment locked
    * @notice
-   * A commitment is locked if its age is within the vote duration.
+   * A commitment is locked until vote duration has elapsed.
    * @dev
    * Assumes active commitment.
    * @param _account - Account owning commitment to check.
@@ -208,7 +208,7 @@ contract TimedVote {
   /**
    * Check proposal open
    * @notice
-   * A proposal is open for voting if its age is within the vote duration.
+   * A proposal is open for voting until vote duration has elapsed.
    * @dev
    * Assumes extant proposal.
    * @param _proposalID - Identifier of proposal to check.
@@ -225,7 +225,7 @@ contract TimedVote {
   /**
    * Get current time
    * @dev
-   * Used as interface to the now timestamp to enable overriding in tests.
+   * Abstracted interface to the current time. Enables overriding in tests.
    * @return isntant - Current instant.
    */
   function time()
@@ -241,7 +241,7 @@ contract TimedVote {
   /**
    * Require proposal closed
    * @dev
-   * Throws if named proposal is open. Assumes extant proposal.
+   * Throws if proposal is open. Assumes extant proposal.
    * @param _proposalID - Identifier of proposal that must be closed.
    */
   modifier onlyClosed(bytes32 _proposalID) {
@@ -255,7 +255,7 @@ contract TimedVote {
   /**
    * Require account committed
    * @dev
-   * Throws if the specified account does not have an active commitment.
+   * Throws if account does not have a commitment.
    * @param _account - Account that must be committed.
    */
   modifier onlyCommitted(address _account) {
@@ -269,7 +269,7 @@ contract TimedVote {
   /**
    * Require proposal extant
    * @dev
-   * Throws if a proposal with the specified identifier does not exist.
+   * Throws if proposal does not exist.
    * @param _proposalID - Identifier for which a proposal must exist.
    */
   modifier onlyExtant(bytes32 _proposalID) {
@@ -283,7 +283,7 @@ contract TimedVote {
   /**
    * Require proposal ID new
    * @dev
-   * Throws if a proposal with the specified identifier already exists.
+   * Throws if identifier refers to an extant proposal.
    * @param _proposalID - Proposal identifier that must be new.
    */
   modifier onlyNew(bytes32 _proposalID) {
@@ -297,7 +297,7 @@ contract TimedVote {
   /**
    * Require proposal open
    * @dev
-   * Throws if named proposal is closed. Assumes extant proposal.
+   * Throws if proposal is closed. Assumes extant proposal.
    * @param _proposalID - Identifier of proposal that must be open.
    */
   modifier onlyOpen(bytes32 _proposalID) {
@@ -311,7 +311,7 @@ contract TimedVote {
   /**
    * Require number positive
    * @dev
-   * Throws if the specified number is not positive.
+   * Throws if number is not positive.
    * @param _number - Number that must be positive.
    */
   modifier onlyPositive(uint256 _number) {
@@ -325,7 +325,7 @@ contract TimedVote {
   /**
    * Require account uncommitted
    * @dev
-   * Throws if the specified account has an active commitment.
+   * Throws if account has active commitment.
    * @param _account - Account that must be uncommitted.
    */
   modifier onlyUncommitted(address _account) {
@@ -339,8 +339,7 @@ contract TimedVote {
   /**
    * Require commitment unlocked
    * @dev
-   * Throws if the commitment of the specified account is locked.
-   * Assumes active commitment.
+   * Throws if commitment is locked. Assumes active commitment.
    * @param _account - Account owning commitment that must be unlocked.
    */
   modifier onlyUnlocked(address _account) {
@@ -354,7 +353,7 @@ contract TimedVote {
   /**
    * Require address valid
    * @dev
-   * Throws if the specified address is the null address.
+   * Throws if address is the null address.
    * @param _address - Address that must be valid.
    */
   modifier onlyValid(address _address) {

--- a/contracts/ownership/TimedVote.sol
+++ b/contracts/ownership/TimedVote.sol
@@ -206,6 +206,23 @@ contract TimedVote {
   }
 
   /**
+   * Check commitment tier 2
+   * @notice
+   * A commitment becomes tier 2 after TIER_2_AGE has elapsed.
+   * @dev
+   * Assumes active commitment. Assumes commitment is not a higher tier.
+   * @param _account - Account owning commitment to check.
+   * @return tier2 - Whether commitment is tier 2.
+   */
+  function commitmentTier2(address _account)
+  internal
+  view
+  returns (bool tier2) {
+    uint256 age = commitmentAge(_account);
+    return (age > TIER_2_AGE);
+  }
+
+  /**
    * Get proposal age
    * @dev
    * Assumes extant proposal.

--- a/contracts/ownership/TimedVote.sol
+++ b/contracts/ownership/TimedVote.sol
@@ -408,6 +408,21 @@ contract TimedVote {
   }
 
   /**
+   * Proposal voting percentage
+   * @notice
+   * Provides what percentage voting MYB amount is of total supply.
+   * @dev
+   * Assumes extant proposal.
+   * @param _proposalID - Identifier of proposal to calculate for.
+   */
+  function votingPercentage(bytes32 _proposalID)
+  internal
+  view
+  returns (uint8 percent) {
+    return percentage(proposals[_proposalID].voted, token.totalSupply());
+  }
+
+  /**
    * Weight vote
    * @param _value - Token amount applied.
    * @param _multiplier - Weighting multiplier.

--- a/contracts/ownership/TimedVote.sol
+++ b/contracts/ownership/TimedVote.sol
@@ -12,8 +12,10 @@ import "../math/SafeMath.sol";
  * vote duration. It passes if a quorum of total MYB supply voted and the
  * approval ratio of weighted votes reaches the required threshold.
  *
- * Provide the address of the MYB token contract and vote duration. Voting for
- * each proposal will be open for the specified duration.
+ * Provide the address of the MYB token contract, vote duration, and quorum.
+ * On each proposal, voting will be open for the specified duration. For a
+ * proposal to be eligible to pass the percent of total MYB that votes must be
+ * at least the quorum.
  */
 contract TimedVote {
   // -------
@@ -65,13 +67,17 @@ contract TimedVote {
    * @param _tokenAddress - MYB token contract address.
    * @param _voteDuration - Vote duration. Voting period of each proposal.
    *     Must be positive.
+   * @param _quorum - Amount of supply that must vote to make a proposal valid.
+   *     Integer percent, eg 20 for 20%. In range 1-100 inclusive.
    */
-  constructor(address _tokenAddress, uint256 _voteDuration)
+  constructor(address _tokenAddress, uint256 _voteDuration, uint8 _quorum)
   public
   onlyValid(_tokenAddress)
-  onlyPositive(_voteDuration) {
+  onlyPositive(_voteDuration)
+  onlyIn(_quorum, 1, 100) {
     token = BurnableToken(_tokenAddress);
     voteDuration = _voteDuration;
+    quorum = _quorum;
   }
 
   // ---------

--- a/contracts/ownership/TimedVote.sol
+++ b/contracts/ownership/TimedVote.sol
@@ -54,6 +54,7 @@ contract TimedVote {
 
   BurnableToken token;                          // MYB token contract
   uint256 voteDuration;                         // Vote duration
+  uint8 quorum;                                 // Quorum
   mapping(address => Commitment) commitments;   // Active commitments
   mapping(bytes32 => Proposal) proposals;       // Created proposals
 

--- a/contracts/ownership/TimedVote.sol
+++ b/contracts/ownership/TimedVote.sol
@@ -226,7 +226,7 @@ contract TimedVote {
    * Get current time
    * @dev
    * Abstracted interface to the current time. Enables overriding in tests.
-   * @return isntant - Current instant.
+   * @return instant - Current instant.
    */
   function time()
   internal

--- a/contracts/ownership/TimedVote.sol
+++ b/contracts/ownership/TimedVote.sol
@@ -27,7 +27,7 @@ contract TimedVote {
   address constant NULL_ADDRESS = address(0);   // Null address
   uint256 constant TIER_2_AGE = 180 days;       // Tier 2 commitment age
   uint256 constant TIER_3_AGE = 365 days;       // Tier 3 commitment age
-  uint8 constant TIER_1_MULTIPLIER = 100;       // Tier 1 multiplier
+  uint8 constant TIER_1_MULTIPLIER = 100;       // Tier 1 multiplier-
   uint8 constant TIER_2_MULTIPLIER = 150;       // Tier 2 multiplier
   uint8 constant TIER_3_MULTIPLIER = 200;       // Tier 3 multiplier
 
@@ -116,6 +116,24 @@ contract TimedVote {
   view
   returns (uint256 value) {
     return commitments[_account].value;
+  }
+
+  /**
+   * Get commitment multiplier
+   * @notice
+   * A commitment multiplier changes as the commitment advances tiers.
+   * Fails if you have no active commitment.
+   * @param _account - Account owning commitment to get the multiplier of.
+   * @return multiplier - Current commitment multiplier.
+   */
+  function multiplierOf(address _account)
+  public
+  view
+  onlyCommitted(msg.sender)
+  returns (uint8 multiplier) {
+    if (commitmentTier3(_account)) return TIER_3_MULTIPLIER;
+    else if (commitmentTier2(_account)) return TIER_2_MULTIPLIER;
+    else return TIER_1_MULTIPLIER;
   }
 
   /**

--- a/contracts/ownership/TimedVote.sol
+++ b/contracts/ownership/TimedVote.sol
@@ -509,9 +509,9 @@ contract TimedVote {
   // Event
 
   event Approve(
-    bytes32 indexed proposalID,
-    address indexed account,
-    uint256 vote
+    bytes32 indexed proposalID,                 // Approved proposal identifier
+    address indexed account,                    // Approving account
+    uint256 vote                                // Weighted approval amount
   );
 
   /** MYB committed to voting */

--- a/contracts/ownership/TimedVote.sol
+++ b/contracts/ownership/TimedVote.sol
@@ -394,6 +394,22 @@ contract TimedVote {
   }
 
   /**
+   * Require maximum 1 vote
+   * @dev
+   * Throws if account has already voted on the proposal.
+   * Assumes extant proposal.
+   * @param _proposalID - Identifier of proposal to check.
+   * @param _account - Account to check.
+   */
+  modifier onlyOneVote(bytes32 _proposalID, address _account) {
+    require(
+      !hasVoted(_account, _proposalID),
+      "Already voted"
+    );
+    _;
+  }
+
+  /**
    * Require proposal open
    * @dev
    * Throws if proposal is closed. Assumes extant proposal.

--- a/contracts/ownership/TimedVote.sol
+++ b/contracts/ownership/TimedVote.sol
@@ -76,7 +76,7 @@ contract TimedVote {
   /**
    * Check account committed
    * @param _account - Account to check.
-   * @return committed - Whether the account has an active commitment.
+   * @return committed - Whether account has an active commitment.
    */
   function accountCommitted(address _account)
   public
@@ -106,7 +106,7 @@ contract TimedVote {
   /**
    * Get account commitment amount
    * @param _account - Account to get commitment amount of.
-   * @return value - MYB amount currently committed by the given account.
+   * @return value - MYB amount currently committed by the account.
    */
   function commitmentOf(address _account)
   external
@@ -118,7 +118,7 @@ contract TimedVote {
   /**
    * Check proposal extant
    * @param _proposalID - Proposal identifier to check.
-   * @return extant - Whether a proposal with the specified identifier exists.
+   * @return extant - Whether proposal with identifier exists.
    */
   function proposalExtant(bytes32 _proposalID)
   public
@@ -165,7 +165,7 @@ contract TimedVote {
   /**
    * Check address null
    * @param _address - Address to check.
-   * @return null_ - Whether the address is the null address.
+   * @return null_ - Whether address is the null address.
    */
   function addressNull(address _address)
   internal
@@ -195,7 +195,7 @@ contract TimedVote {
    * @dev
    * Assumes active commitment.
    * @param _account - Account owning commitment to check.
-   * @return locked - Whether commitment of the specified account is locked.
+   * @return locked - Whether commitment is locked.
    */
   function commitmentLocked(address _account)
   internal
@@ -212,7 +212,7 @@ contract TimedVote {
    * @dev
    * Assumes extant proposal.
    * @param _proposalID - Identifier of proposal to check.
-   * @return open - Whether proposal with the specified identifier is open.
+   * @return open - Whether proposal is open.
    */
   function proposalOpen(bytes32 _proposalID)
   internal

--- a/contracts/ownership/TimedVote.sol
+++ b/contracts/ownership/TimedVote.sol
@@ -715,6 +715,7 @@ contract TimedVote {
   // -----
   // Event
 
+  /** Approve vote cast */
   event Approve(
     bytes32 indexed proposalID,                 // Approved proposal identifier
     address indexed account,                    // Approving account

--- a/contracts/ownership/TimedVote.sol
+++ b/contracts/ownership/TimedVote.sol
@@ -728,6 +728,7 @@ contract TimedVote {
     uint256 value                               // MYB amount committed
   );
 
+  /** Decline vote cast */
   event Decline(
     bytes32 indexed proposalID,                 // Declined proposal identifier
     address indexed account,                    // Declining account

--- a/contracts/ownership/TimedVote.sol
+++ b/contracts/ownership/TimedVote.sol
@@ -225,6 +225,23 @@ contract TimedVote {
   }
 
   /**
+   * Check commitment tier 3
+   * @notice
+   * A commitment becomes tier 3 after TIER_3_AGE has elapsed.
+   * @dev
+   * Assumes active commitment. Assumes commitment is not a higher tier.
+   * @param _account - Account owning commitment to check.
+   * @return tier3 - Whether commitment is tier 3.
+   */
+  function commitmentTier3(address _account)
+  internal
+  view
+  returns (bool tier3) {
+    uint256 age = commitmentAge(_account);
+    return (age > TIER_3_AGE);
+  }
+
+  /**
    * Get proposal age
    * @dev
    * Assumes extant proposal.

--- a/contracts/ownership/TimedVote.sol
+++ b/contracts/ownership/TimedVote.sol
@@ -57,6 +57,7 @@ contract TimedVote {
   BurnableToken token;                          // MYB token contract
   uint256 voteDuration;                         // Vote duration
   uint8 quorum;                                 // Quorum
+  uint8 threshold;                              // Approval threshold
   mapping(address => Commitment) commitments;   // Active commitments
   mapping(bytes32 => Proposal) proposals;       // Created proposals
 

--- a/contracts/ownership/TimedVote.sol
+++ b/contracts/ownership/TimedVote.sol
@@ -578,20 +578,6 @@ contract TimedVote {
   }
 
   /**
-   * Require proposal meets quorum
-   * @dev
-   * Throws if proposal does not meet quorum. Assumes extant proposal.
-   * @param _proposalID - Identifier of proposal that must meet quorum.
-   */
-  modifier onlyMeetsQuorum(bytes32 _proposalID) {
-    require(
-      meetsQuorum(_proposalID),
-      "Quorum not met"
-    );
-    _;
-  }
-
-  /**
    * Require proposal ID new
    * @dev
    * Throws if identifier refers to an extant proposal.

--- a/contracts/ownership/TimedVote.sol
+++ b/contracts/ownership/TimedVote.sol
@@ -201,7 +201,7 @@ contract TimedVote {
   internal
   view
   returns (bool locked) {
-    uint256 age = time().sub(commitments[_account].time);
+    uint256 age = commitmentAge(_account);
     return (age <= voteDuration);
   }
 

--- a/contracts/ownership/TimedVote.sol
+++ b/contracts/ownership/TimedVote.sol
@@ -528,7 +528,7 @@ contract TimedVote {
 
   /** Commitment withdrawn */
   event Withdraw(
-    address indexed account,
-    uint256 value
+    address indexed account,                    // Withdrawing account
+    uint256 value                               // MYB amount withdrawn
   );
 }

--- a/contracts/ownership/TimedVote.sol
+++ b/contracts/ownership/TimedVote.sol
@@ -26,6 +26,7 @@ contract TimedVote {
 
   address constant NULL_ADDRESS = address(0);   // Null address
   uint256 constant TIER_2_AGE = 180 days;       // Tier 2 commitment age
+  uint256 constant TIER_3_AGE = 365 days;       // Tier 3 commitment age
   uint8 constant TIER_2_MULTIPLIER = 150;       // Tier 2 multiplier
 
   // ----

--- a/contracts/ownership/TimedVote.sol
+++ b/contracts/ownership/TimedVote.sol
@@ -12,10 +12,11 @@ import "../math/SafeMath.sol";
  * vote duration. It passes if a quorum of total MYB supply voted and the
  * approval ratio of weighted votes reaches the required threshold.
  *
- * Provide the address of the MYB token contract, vote duration, and quorum.
- * On each proposal, voting will be open for the specified duration. For a
- * proposal to be eligible to pass the percent of total MYB that votes must be
- * at least the quorum.
+ * Provide the address of the MYB token contract, vote duration, quorum, and
+ * approval threshold. On each proposal, voting will be open for the specified
+ * duration. For a proposal to be eligible to pass the percent of total MYB
+ * that votes must be at least the quorum. For a proposal to pass the percent
+ * of weighted votes that are approval must be at least the approval threshold.
  */
 contract TimedVote {
   // -------
@@ -70,15 +71,25 @@ contract TimedVote {
    *     Must be positive.
    * @param _quorum - Amount of supply that must vote to make a proposal valid.
    *     Integer percent, eg 20 for 20%. In range 1-100 inclusive.
+   * @param _threshold - Amount of weighted votes that must be approval for a
+   *     proposal to pass. Integer percent, eg 51 for 51%. In range 1-100
+   *     inclusive.
    */
-  constructor(address _tokenAddress, uint256 _voteDuration, uint8 _quorum)
+  constructor(
+    address _tokenAddress,
+    uint256 _voteDuration,
+    uint8 _quorum,
+    uint8 _threshold
+  )
   public
   onlyValid(_tokenAddress)
   onlyPositive(_voteDuration)
-  onlyIn(_quorum, 1, 100) {
+  onlyIn(_quorum, 1, 100)
+  onlyIn(_threshold, 1, 100) {
     token = BurnableToken(_tokenAddress);
     voteDuration = _voteDuration;
     quorum = _quorum;
+    threshold = _threshold;
   }
 
   // ---------

--- a/contracts/ownership/TimedVote.sol
+++ b/contracts/ownership/TimedVote.sol
@@ -8,9 +8,9 @@ import "../math/SafeMath.sol";
  * @notice
  * Anyone can create a proposal. An MYB holder can lock their tokens to become
  * a voter. Voters may approve or decline proposals. Vote weight increases as
- * tokens are locked for longer periods. A proposal closes after 15 days. It
- * passes if a 20% quorum of total MYB supply voted and 51% of weighted votes
- * approved.
+ * tokens are locked for longer periods. A proposal closes after a configurable
+ * vote duration. It passes if a quorum of total MYB supply voted and the
+ * approval ratio of weighted votes crosses the required threshold.
  *
  * Provide the address of the MYB token contract and vote duration. Voting for
  * each proposal will be open for the specified duration.

--- a/contracts/ownership/TimedVote.sol
+++ b/contracts/ownership/TimedVote.sol
@@ -109,7 +109,7 @@ contract TimedVote {
     uint256 value = commitments[msg.sender].value;
     proposal.voted = proposal.voted.add(value);
     uint8 multiplier = multiplierOf(msg.sender);
-    uint256 vote = weightVote(commitments[msg.sender].value, multiplier);
+    uint256 vote = weightVote(value, multiplier);
     proposal.approval = proposal.approval.add(vote);
     emit Approve(_proposalID, msg.sender, vote);
   }

--- a/contracts/ownership/TimedVote.sol
+++ b/contracts/ownership/TimedVote.sol
@@ -234,6 +234,24 @@ contract TimedVote {
   }
 
   /**
+   * Get proposal result
+   * @notice
+   * Returns the final result of the proposal. A proposal passes if it meets
+   * quorum and meets the approval threshold. Fails if the proposal does not
+   * exist. Fails if the proposal is still open for voting.
+   * @param _proposalID - Identifier of proposal to get result of.
+   * @return passed - Whether the proposal passed.
+   */
+  function result(bytes32 _proposalID)
+  external
+  view
+  onlyExtant(_proposalID)
+  onlyClosed(_proposalID)
+  returns (bool passed) {
+    return (meetsQuorum(_proposalID) && meetsThreshold(_proposalID));
+  }
+
+  /**
    * Withdraw committed MYB
    * @notice
    * Withdraws all of your committed MYB to the original address. Fails if you

--- a/contracts/ownership/TimedVote.sol
+++ b/contracts/ownership/TimedVote.sol
@@ -367,6 +367,20 @@ contract TimedVote {
   }
 
   /**
+   * Check proposal meets quorum
+   * @dev
+   * Assumes extant proposal.
+   * @param _proposalID - Identiier of proposal to check.
+   * @return meets - Whether proposal meets quorum.
+   */
+  function meetsQuorum(bytes32 _proposalID)
+  internal
+  view
+  returns (bool meets) {
+    return (votingPercentage(_proposalID) >= quorum);
+  }
+
+  /**
    * Percentage
    * @notice
    * Provides percentage portion is of total.

--- a/contracts/ownership/TimedVote.sol
+++ b/contracts/ownership/TimedVote.sol
@@ -232,7 +232,7 @@ contract TimedVote {
   internal
   view
   returns (bool open) {
-    uint256 age = time().sub(proposals[_proposalID].start);
+    uint256 age = proposalAge(_proposalID);
     return (age <= voteDuration);
   }
 

--- a/contracts/ownership/TimedVote.sol
+++ b/contracts/ownership/TimedVote.sol
@@ -153,6 +153,8 @@ contract TimedVote {
 
   /**
    * Get account commitment amount
+   * @notice
+   * Returns 0 if account has no commitment.
    * @param _account - Account to get commitment amount of.
    * @return value - MYB amount currently committed by the account.
    */

--- a/contracts/ownership/TimedVote.sol
+++ b/contracts/ownership/TimedVote.sol
@@ -261,6 +261,23 @@ contract TimedVote {
   }
 
   /**
+   * Check account has voted
+   * @notice
+   * Checks whether account has voted on a proposal.
+   * @dev
+   * Assumes extant proposal.
+   * @param _account - Account to check.
+   * @param _proposalID - Identifier of proposal to check.
+   * @return voted - Whether account has voted on the proposal.
+   */
+  function hasVoted(address _account, bytes32 _proposalID)
+  internal
+  view
+  returns (bool voted) {
+    return proposals[_proposalID].voters[_account];
+  }
+
+  /**
    * Get proposal age
    * @dev
    * Assumes extant proposal.

--- a/contracts/ownership/TimedVote.sol
+++ b/contracts/ownership/TimedVote.sol
@@ -252,6 +252,41 @@ contract TimedVote {
   }
 
   /**
+   * Get proposal status.
+   * @notice
+   * Provides the current status of an approval. May be called during voting
+   * to get the status so far. Fails if the proposal does not exist. Use
+   * #result after voting close to get the final result.
+   * @param _proposalID - Identifier of proposal to get status of.
+   * @return open - Whether the proposal is open.
+   * @return age - Proposal age. Voting closes after voteDuration.
+   * @return voted - Voting MYB amount. Must meet quorum to pass.
+   * @return approval - Weighted approval amount. Ratio with total votes
+   *     must meet threshold to pass.
+   * @return dissent - Weighted dissent amount.
+   */
+  function status(bytes32 _proposalID)
+  external
+  view
+  onlyExtant(_proposalID)
+  returns (
+    bool open,
+    uint256 age,
+    uint256 voted,
+    uint256 approval,
+    uint256 dissent
+  ) {
+    Proposal storage proposal = proposals[_proposalID];
+    return (
+      proposalOpen(_proposalID),
+      proposalAge(_proposalID),
+      proposal.voted,
+      proposal.approval,
+      proposal.dissent
+    );
+  }
+
+  /**
    * Withdraw committed MYB
    * @notice
    * Withdraws all of your committed MYB to the original address. Fails if you

--- a/contracts/ownership/TimedVote.sol
+++ b/contracts/ownership/TimedVote.sol
@@ -516,8 +516,8 @@ contract TimedVote {
 
   /** MYB committed to voting */
   event Commit(
-    address indexed account,
-    uint256 value
+    address indexed account,                    // Committing account
+    uint256 value                               // MYB amount committed
   );
 
   /** Proposal created */

--- a/contracts/ownership/TimedVote.sol
+++ b/contracts/ownership/TimedVote.sol
@@ -349,6 +349,21 @@ contract TimedVote {
   }
 
   /**
+   * Percentage
+   * @notice
+   * Provides percentage portion is of total.
+   * @param _portion - Portion to calculate percentage for.
+   * @param _total - Total to calculate percentage of.
+   * @return percent - Percentage portion is of total. Integer percent.
+   */
+  function percentage(uint256 _portion, uint256 _total)
+  internal
+  pure
+  returns (uint8 percent) {
+    return uint8(_portion.mul(100).div(_total));
+  }
+
+  /**
    * Get proposal age
    * @dev
    * Assumes extant proposal.

--- a/contracts/ownership/TimedVote.sol
+++ b/contracts/ownership/TimedVote.sol
@@ -27,6 +27,7 @@ contract TimedVote {
   address constant NULL_ADDRESS = address(0);   // Null address
   uint256 constant TIER_2_AGE = 180 days;       // Tier 2 commitment age
   uint256 constant TIER_3_AGE = 365 days;       // Tier 3 commitment age
+  uint8 constant TIER_1_MULTIPLIER = 100;       // Tier 1 multiplier
   uint8 constant TIER_2_MULTIPLIER = 150;       // Tier 2 multiplier
   uint8 constant TIER_3_MULTIPLIER = 200;       // Tier 3 multiplier
 

--- a/contracts/ownership/TimedVote.sol
+++ b/contracts/ownership/TimedVote.sol
@@ -304,6 +304,19 @@ contract TimedVote {
     return now;
   }
 
+  /**
+   * Weight vote
+   * @param _value - Token amount applied.
+   * @param _multiplier - Weighting multiplier.
+   * @return vote - Weighted vote amount.
+   */
+  function weightVote(uint256 _value, uint8 _multiplier)
+  internal
+  pure
+  returns (uint256 vote) {
+    return _value.mul(_multiplier).div(100);
+  }
+
   // --------
   // Modifier
 

--- a/contracts/ownership/TimedVote.sol
+++ b/contracts/ownership/TimedVote.sol
@@ -226,12 +226,12 @@ contract TimedVote {
    * Get current time
    * @dev
    * Used as interface to the now timestamp to enable overriding in tests.
-   * @return timestamp - Current instant.
+   * @return isntant - Current instant.
    */
   function time()
   internal
   view
-  returns (uint256 timestamp) {
+  returns (uint256 instant) {
     return now;
   }
 

--- a/contracts/ownership/TimedVote.sol
+++ b/contracts/ownership/TimedVote.sol
@@ -193,7 +193,7 @@ contract TimedVote {
    * Get commitment multiplier
    * @notice
    * A commitment multiplier changes as the commitment advances tiers.
-   * Fails if you have no active commitment.
+   * Fails if account has no active commitment.
    * @param _account - Account owning commitment to get the multiplier of.
    * @return multiplier - Current commitment multiplier.
    */

--- a/contracts/ownership/TimedVote.sol
+++ b/contracts/ownership/TimedVote.sol
@@ -28,6 +28,7 @@ contract TimedVote {
   uint256 constant TIER_2_AGE = 180 days;       // Tier 2 commitment age
   uint256 constant TIER_3_AGE = 365 days;       // Tier 3 commitment age
   uint8 constant TIER_2_MULTIPLIER = 150;       // Tier 2 multiplier
+  uint8 constant TIER_3_MULTIPLIER = 200;       // Tier 3 multiplier
 
   // ----
   // Type

--- a/contracts/ownership/TimedVote.sol
+++ b/contracts/ownership/TimedVote.sol
@@ -522,8 +522,8 @@ contract TimedVote {
 
   /** Proposal created */
   event Propose(
-    address indexed proposer,
-    bytes32 proposalID
+    address indexed proposer,                   // Proposing account
+    bytes32 proposalID                          // Proposal identifier
   );
 
   /** Commitment withdrawn */

--- a/contracts/ownership/TimedVote.sol
+++ b/contracts/ownership/TimedVote.sol
@@ -408,6 +408,22 @@ contract TimedVote {
   }
 
   /**
+   * Proposal total votes
+   * @notice
+   * Provides total weighted votes cast on the proposal.
+   * Sum of weighted approval and weighted dissent.
+   * @param _proposalID - Identifier of proposal to calculate for.
+   * @return votes - Total weighted votes cast on the proposal.
+   */
+  function totalVotes(bytes32 _proposalID)
+  internal
+  view
+  returns (uint256 votes) {
+    return proposals[_proposalID].approval
+      .add(proposals[_proposalID].dissent);
+  }
+
+  /**
    * Proposal voting percentage
    * @notice
    * Provides what percentage voting MYB amount is of total supply.

--- a/contracts/ownership/TimedVote.sol
+++ b/contracts/ownership/TimedVote.sol
@@ -10,7 +10,7 @@ import "../math/SafeMath.sol";
  * a voter. Voters may approve or decline proposals. Vote weight increases as
  * tokens are locked for longer periods. A proposal closes after a configurable
  * vote duration. It passes if a quorum of total MYB supply voted and the
- * approval ratio of weighted votes crosses the required threshold.
+ * approval ratio of weighted votes reaches the required threshold.
  *
  * Provide the address of the MYB token contract and vote duration. Voting for
  * each proposal will be open for the specified duration.

--- a/contracts/ownership/TimedVote.sol
+++ b/contracts/ownership/TimedVote.sol
@@ -560,6 +560,20 @@ contract TimedVote {
   }
 
   /**
+   * Require proposal meets quorum
+   * @dev
+   * Throws if proposal does not meet quorum. Assumes extant proposal.
+   * @param _proposalID - Identifier of proposal that must meet quorum.
+   */
+  modifier onlyMeetsQuorum(bytes32 _proposalID) {
+    require(
+      meetsQuorum(_proposalID),
+      "Quorum not met"
+    );
+    _;
+  }
+
+  /**
    * Require proposal ID new
    * @dev
    * Throws if identifier refers to an extant proposal.

--- a/contracts/ownership/TimedVote.sol
+++ b/contracts/ownership/TimedVote.sol
@@ -432,6 +432,24 @@ contract TimedVote {
   }
 
   /**
+   * Require number in range
+   * @notice
+   * Number must be in range minimum through maximum inclusive.
+   * @dev
+   * Throws id number is outside range.
+   * @param number - Number that must be in range.
+   * @param minimum - Lower limit.
+   * @param maximum - Upper limit.
+   */
+  modifier onlyIn(uint8 number, uint8 minimum, uint8 maximum) {
+    require(
+      number >= minimum && number <= maximum,
+      "Number outside valid range"
+    );
+    _;
+  }
+
+  /**
    * Require proposal ID new
    * @dev
    * Throws if identifier refers to an extant proposal.

--- a/contracts/ownership/TimedVote.sol
+++ b/contracts/ownership/TimedVote.sol
@@ -200,7 +200,7 @@ contract TimedVote {
   function multiplierOf(address _account)
   public
   view
-  onlyCommitted(msg.sender)
+  onlyCommitted(_account)
   returns (uint8 multiplier) {
     if (commitmentTier3(_account)) return TIER_3_MULTIPLIER;
     else if (commitmentTier2(_account)) return TIER_2_MULTIPLIER;

--- a/contracts/ownership/TimedVote.sol
+++ b/contracts/ownership/TimedVote.sol
@@ -267,6 +267,24 @@ contract TimedVote {
   }
 
   /**
+   * Proposal approval percentage
+   * @notice
+   * Provides what percentage proposal approval is of total weighted votes.
+   * @dev
+   * Assumes extant proposal. Assumes nonzero total votes.
+   * @param _proposalID - Identifier of proposal to calculate for.
+   */
+  function approvalPercentage(bytes32 _proposalID)
+  internal
+  view
+  returns (uint8 percent) {
+    return percentage(
+      proposals[_proposalID].approval,
+      totalVotes(_proposalID)
+    );
+  }
+
+  /**
    * Get commitment age
    * @dev
    * Assumes active commitment.

--- a/contracts/ownership/TimedVote.sol
+++ b/contracts/ownership/TimedVote.sol
@@ -381,6 +381,19 @@ contract TimedVote {
   }
 
   /**
+   * Check proposal meets threshold
+   * @dev
+   * Assumes extant proposal. Assumes nonzero total votes.
+   * @param _proposalID - Identifier of proposal to calculate for.
+   */
+  function meetsThreshold(bytes32 _proposalID)
+  internal
+  view
+  returns (bool meets) {
+    return (approvalPercentage(_proposalID) >= threshold);
+  }
+
+  /**
    * Percentage
    * @notice
    * Provides percentage portion is of total.

--- a/contracts/test/TimedVoteFixture.sol
+++ b/contracts/test/TimedVoteFixture.sol
@@ -99,6 +99,14 @@ contract TimedVoteFixture is TimedVote {
   pure
   onlyValid(_address) {}
 
+  /** Get proposal age */
+  function _proposalAge(bytes32 _proposalID)
+  external
+  view
+  returns (uint256 age) {
+    return proposalAge(_proposalID);
+  }
+
   /** Check proposal open */
   function _proposalOpen(bytes32 _proposalID)
   external

--- a/contracts/test/TimedVoteFixture.sol
+++ b/contracts/test/TimedVoteFixture.sol
@@ -139,6 +139,14 @@ contract TimedVoteFixture is TimedVote {
   pure
   onlyValid(_address) {}
 
+  /** Percentage */
+  function _percentage(uint256 _portion, uint256 _total)
+  external
+  pure
+  returns (uint8 percent) {
+    return percentage(_portion, _total);
+  }
+
   /** Get proposal age */
   function _proposalAge(bytes32 _proposalID)
   external

--- a/contracts/test/TimedVoteFixture.sol
+++ b/contracts/test/TimedVoteFixture.sol
@@ -163,6 +163,14 @@ contract TimedVoteFixture is TimedVote {
     return proposalOpen(_proposalID);
   }
 
+  /** Proposal voting percentage */
+  function _votingPercentage(bytes32 _proposalID)
+  external
+  view
+  returns (uint8 percent) {
+    return votingPercentage(_proposalID);
+  }
+
   /** Weight vote */
   function _weightVote(uint256 _value, uint8 _multiplier)
   external

--- a/contracts/test/TimedVoteFixture.sol
+++ b/contracts/test/TimedVoteFixture.sol
@@ -12,9 +12,9 @@ contract TimedVoteFixture is TimedVote {
   // Constructor
 
   /** Relay all arguments */
-  constructor(address _tokenAddress, uint256 _voteDuration)
+  constructor(address _tokenAddress, uint256 _voteDuration, uint8 _quorum)
   public
-  TimedVote(_tokenAddress, _voteDuration) {
+  TimedVote(_tokenAddress, _voteDuration, _quorum) {
     timestamp = now;
   }
 

--- a/contracts/test/TimedVoteFixture.sol
+++ b/contracts/test/TimedVoteFixture.sol
@@ -61,6 +61,14 @@ contract TimedVoteFixture is TimedVote {
     return commitmentTier3(_account);
   }
 
+  /** Check account has voted */
+  function _hasVoted(address _account, bytes32 _proposalID)
+  external
+  view
+  returns (bool voted) {
+    return hasVoted(_account, _proposalID);
+  }
+
   /** Require proposal closed */
   function _onlyClosedProposal(bytes32 _proposalID)
   external
@@ -159,6 +167,16 @@ contract TimedVoteFixture is TimedVote {
   function _setCommitment(address _account, uint256 _amount)
   external {
     commitments[_account] = Commitment(_amount, time());
+  }
+
+  /**
+   * Set account voted
+   * @param _proposalID - Identifier of proposal to set vote on.
+   * @param _account - Account to set voted for.
+   */
+  function _setVoted(bytes32 _proposalID, address _account)
+  external {
+    proposals[_proposalID].voters[_account] = true;
   }
 
   /**

--- a/contracts/test/TimedVoteFixture.sol
+++ b/contracts/test/TimedVoteFixture.sol
@@ -3,6 +3,11 @@ pragma solidity 0.4.24;
 import "../ownership/TimedVote.sol";
 
 contract TimedVoteFixture is TimedVote {
+  // -----
+  // State
+
+  uint256 timestamp;                            // Artificial now timestamp
+
   // -----------
   // Constructor
 

--- a/contracts/test/TimedVoteFixture.sol
+++ b/contracts/test/TimedVoteFixture.sol
@@ -45,6 +45,14 @@ contract TimedVoteFixture is TimedVote {
     return commitmentLocked(_account);
   }
 
+  /** Check commitment tier 2 */
+  function _commitmentTier2(address _account)
+  external
+  view
+  returns (bool tier2) {
+    return commitmentTier2(_account);
+  }
+
   /** Require proposal closed */
   function _onlyClosedProposal(bytes32 _proposalID)
   external

--- a/contracts/test/TimedVoteFixture.sol
+++ b/contracts/test/TimedVoteFixture.sol
@@ -14,7 +14,9 @@ contract TimedVoteFixture is TimedVote {
   /** Relay all arguments */
   constructor(address _tokenAddress, uint256 _voteDuration)
   public
-  TimedVote(_tokenAddress, _voteDuration) {}
+  TimedVote(_tokenAddress, _voteDuration) {
+    timestamp = now;
+  }
 
   // --------
   // Revealer

--- a/contracts/test/TimedVoteFixture.sol
+++ b/contracts/test/TimedVoteFixture.sol
@@ -120,49 +120,6 @@ contract TimedVoteFixture is TimedVote {
   }
 
   /**
-   * Advance commitment time by seconds
-   * @param _account - Account owning commitment to advance.
-   * @param _seconds - Seconds to advance.
-   */
-  function _advanceCommitmentSeconds(address _account, uint256 _seconds)
-  public {
-    commitments[_account].time = commitments[_account].time.sub(_seconds);
-  }
-
-  /**
-   * Advance commitment time by minutes
-   * @param _account - Account owning commitment to advance.
-   * @param _minutes - Minutes to advance.
-   */
-  function _advanceCommitmentMinutes(address _account, uint256 _minutes)
-  public {
-    uint256 _seconds = _minutes.mul(60);
-    _advanceCommitmentSeconds(_account, _seconds);
-  }
-
-  /**
-   * Advance commitment time by hours
-   * @param _account - Account owning commitment to advance.
-   * @param _hours - Hours to advance.
-   */
-  function _advanceCommitmentHours(address _account, uint256 _hours)
-  public {
-    uint256 _minutes = _hours.mul(60);
-    _advanceCommitmentMinutes(_account, _minutes);
-  }
-
-  /**
-   * Advance commitment time by days
-   * @param _account - Account owning commitment to advance.
-   * @param _days - Days to advance.
-   */
-  function _advanceCommitmentDays(address _account, uint256 _days)
-  external {
-    uint256 _hours = _days.mul(24);
-    _advanceCommitmentHours(_account, _hours);
-  }
-
-  /**
    * Set account commitment
    * @param _account - Account to set commitment of.
    * @param _amount - MYB commitment amount.

--- a/contracts/test/TimedVoteFixture.sol
+++ b/contracts/test/TimedVoteFixture.sol
@@ -131,6 +131,14 @@ contract TimedVoteFixture is TimedVote {
     return proposalOpen(_proposalID);
   }
 
+  /** Weight vote */
+  function _weightVote(uint256 _value, uint8 _multiplier)
+  external
+  pure
+  returns (uint256 vote) {
+    return weightVote(_value, _multiplier);
+  }
+
   // ------
   // Writer
 

--- a/contracts/test/TimedVoteFixture.sol
+++ b/contracts/test/TimedVoteFixture.sol
@@ -87,6 +87,11 @@ contract TimedVoteFixture is TimedVote {
   view
   onlyExtant(_proposalID) {}
 
+  function _onlyIn(uint8 number, uint8 minimum, uint8 maximum)
+  external
+  pure
+  onlyIn(number, minimum, maximum) {}
+
   /** Require proposal ID new */
   function _onlyNew(bytes32 _proposalID)
   external

--- a/contracts/test/TimedVoteFixture.sol
+++ b/contracts/test/TimedVoteFixture.sol
@@ -215,6 +215,45 @@ contract TimedVoteFixture is TimedVote {
     commitments[_account] = Commitment(_amount, time());
   }
 
+  /**
+   * Advance time by seconds
+   * @param _seconds - Seconds to advance.
+   */
+  function _timeTravelSeconds(uint256 _seconds)
+  public {
+    timestamp = timestamp.add(_seconds);
+  }
+
+  /**
+   * Advance time by minutes
+   * @param _minutes - Minutes to advance.
+   */
+  function _timeTravelMinutes(uint256 _minutes)
+  public {
+    uint256 _seconds = _minutes.mul(60);
+    _timeTravelSeconds(_seconds);
+  }
+
+  /**
+   * Advance time by hours
+   * @param _hours - Hours to advance.
+   */
+  function _timeTravelHours(uint256 _hours)
+  public {
+    uint256 _minutes = _hours.mul(60);
+    _timeTravelMinutes(_minutes);
+  }
+
+  /**
+   * Advance time by days
+   * @param _days - Days to advance.
+   */
+  function _timeTravelDays(uint256 _days)
+  external {
+    uint256 _hours = _days.mul(24);
+    _timeTravelHours(_hours);
+  }
+
   // --------
   // Override
   // --------

--- a/contracts/test/TimedVoteFixture.sol
+++ b/contracts/test/TimedVoteFixture.sol
@@ -121,6 +121,12 @@ contract TimedVoteFixture is TimedVote {
   pure
   onlyIn(number, minimum, maximum) {}
 
+  /** Require proposal meets quorum */
+  function _onlyMeetsQuorum(bytes32 _proposalID)
+  external
+  view
+  onlyMeetsQuorum(_proposalID) {}
+
   /** Require proposal ID new */
   function _onlyNew(bytes32 _proposalID)
   external

--- a/contracts/test/TimedVoteFixture.sol
+++ b/contracts/test/TimedVoteFixture.sol
@@ -214,4 +214,21 @@ contract TimedVoteFixture is TimedVote {
   external {
     commitments[_account] = Commitment(_amount, time());
   }
+
+  // --------
+  // Override
+  // --------
+
+  /**
+   * Get artificial current time
+   * @dev
+   * Provides an artificial now timestamp. Enables control of time in tests.
+   * @return instant - Artificial current instant.
+   */
+  function time()
+  internal
+  view
+  returns (uint256 instant) {
+    return timestamp;
+  }
 }

--- a/contracts/test/TimedVoteFixture.sol
+++ b/contracts/test/TimedVoteFixture.sol
@@ -121,12 +121,6 @@ contract TimedVoteFixture is TimedVote {
   pure
   onlyIn(number, minimum, maximum) {}
 
-  /** Require proposal meets quorum */
-  function _onlyMeetsQuorum(bytes32 _proposalID)
-  external
-  view
-  onlyMeetsQuorum(_proposalID) {}
-
   /** Require proposal ID new */
   function _onlyNew(bytes32 _proposalID)
   external

--- a/contracts/test/TimedVoteFixture.sol
+++ b/contracts/test/TimedVoteFixture.sol
@@ -114,7 +114,7 @@ contract TimedVoteFixture is TimedVote {
    */
   function _addProposal(bytes32 _proposalID)
   external {
-    proposals[_proposalID] = Proposal(now, 0, 0, 0);
+    proposals[_proposalID] = Proposal(time(), 0, 0, 0);
   }
 
   /**
@@ -210,6 +210,6 @@ contract TimedVoteFixture is TimedVote {
    */
   function _setCommitment(address _account, uint256 _amount)
   external {
-    commitments[_account] = Commitment(_amount, now);
+    commitments[_account] = Commitment(_amount, time());
   }
 }

--- a/contracts/test/TimedVoteFixture.sol
+++ b/contracts/test/TimedVoteFixture.sol
@@ -210,7 +210,6 @@ contract TimedVoteFixture is TimedVote {
    */
   function _setCommitment(address _account, uint256 _amount)
   external {
-    commitments[_account].value = _amount;
-    commitments[_account].time = now;
+    commitments[_account] = Commitment(_amount, now);
   }
 }

--- a/contracts/test/TimedVoteFixture.sol
+++ b/contracts/test/TimedVoteFixture.sol
@@ -242,11 +242,11 @@ contract TimedVoteFixture is TimedVote {
   }
 
   /**
-   * Set account voted
-   * @param _proposalID - Identifier of proposal to set vote on.
-   * @param _account - Account to set voted for.
+   * Set account voter
+   * @param _proposalID - Identifier of proposal to make a voter on.
+   * @param _account - Account to make a voter.
    */
-  function _setVoted(bytes32 _proposalID, address _account)
+  function _setVoter(bytes32 _proposalID, address _account)
   external {
     proposals[_proposalID].voters[_account] = true;
   }

--- a/contracts/test/TimedVoteFixture.sol
+++ b/contracts/test/TimedVoteFixture.sol
@@ -53,6 +53,13 @@ contract TimedVoteFixture is TimedVote {
     return commitmentTier2(_account);
   }
 
+  function _commitmentTier3(address _account)
+  external
+  view
+  returns (bool tier3) {
+    return commitmentTier3(_account);
+  }
+
   /** Require proposal closed */
   function _onlyClosedProposal(bytes32 _proposalID)
   external

--- a/contracts/test/TimedVoteFixture.sol
+++ b/contracts/test/TimedVoteFixture.sol
@@ -12,9 +12,14 @@ contract TimedVoteFixture is TimedVote {
   // Constructor
 
   /** Relay all arguments */
-  constructor(address _tokenAddress, uint256 _voteDuration, uint8 _quorum)
+  constructor(
+    address _tokenAddress,
+    uint256 _voteDuration,
+    uint8 _quorum,
+    uint8 _threshold
+  )
   public
-  TimedVote(_tokenAddress, _voteDuration, _quorum) {
+  TimedVote(_tokenAddress, _voteDuration, _quorum, _threshold) {
     timestamp = now;
   }
 

--- a/contracts/test/TimedVoteFixture.sol
+++ b/contracts/test/TimedVoteFixture.sol
@@ -34,6 +34,14 @@ contract TimedVoteFixture is TimedVote {
     return addressNull(_address);
   }
 
+  /** Proposal approval percentage */
+  function _approvalPercentage(bytes32 _proposalID)
+  external
+  view
+  returns (uint8 percent) {
+    return approvalPercentage(_proposalID);
+  }
+
   /** Get commitment age */
   function _commitmentAge(address _account)
   external

--- a/contracts/test/TimedVoteFixture.sol
+++ b/contracts/test/TimedVoteFixture.sol
@@ -90,6 +90,14 @@ contract TimedVoteFixture is TimedVote {
     return meetsQuorum(_proposalID);
   }
 
+  /** Check proposal meets threshold */
+  function _meetsThreshold(bytes32 _proposalID)
+  external
+  view
+  returns (bool meets) {
+    return meetsThreshold(_proposalID);
+  }
+
   /** Require proposal closed */
   function _onlyClosedProposal(bytes32 _proposalID)
   external

--- a/contracts/test/TimedVoteFixture.sol
+++ b/contracts/test/TimedVoteFixture.sol
@@ -93,6 +93,12 @@ contract TimedVoteFixture is TimedVote {
   view
   onlyNew(_proposalID) {}
 
+  /** Require maximum 1 vote */
+  function _onlyOneVote(bytes32 _proposalID, address _account)
+  external
+  view
+  onlyOneVote(_proposalID, _account) {}
+
   /** Require proposal open */
   function _onlyOpenProposal(bytes32 _proposalID)
   external

--- a/contracts/test/TimedVoteFixture.sol
+++ b/contracts/test/TimedVoteFixture.sol
@@ -163,6 +163,14 @@ contract TimedVoteFixture is TimedVote {
     return proposalOpen(_proposalID);
   }
 
+  /** Proposal total votes */
+  function _totalVotes(bytes32 _proposalID)
+  external
+  view
+  returns (uint256 votes) {
+    return totalVotes(_proposalID);
+  }
+
   /** Proposal voting percentage */
   function _votingPercentage(bytes32 _proposalID)
   external
@@ -192,6 +200,18 @@ contract TimedVoteFixture is TimedVote {
   }
 
   /**
+   * Set proposal approval
+   * @dev
+   * Assumes extant proposal.
+   * @param _proposalID - Identifier of proposal.
+   * @param _approval - Approval amount.
+   */
+  function _setApproval(bytes32 _proposalID, uint256 _approval)
+  external {
+    proposals[_proposalID].approval = _approval;
+  }
+
+  /**
    * Set account commitment
    * @param _account - Account to set commitment of.
    * @param _amount - MYB commitment amount.
@@ -199,6 +219,18 @@ contract TimedVoteFixture is TimedVote {
   function _setCommitment(address _account, uint256 _amount)
   external {
     commitments[_account] = Commitment(_amount, time());
+  }
+
+  /**
+   * Set proposal dissent
+   * @dev
+   * Assumes extant proposal.
+   * @param _proposalID - Identifier of proposal.
+   * @param _dissent - Dissent amount.
+   */
+  function _setDissent(bytes32 _proposalID, uint256 _dissent)
+  external {
+    proposals[_proposalID].dissent = _dissent;
   }
 
   /**

--- a/contracts/test/TimedVoteFixture.sol
+++ b/contracts/test/TimedVoteFixture.sol
@@ -53,6 +53,7 @@ contract TimedVoteFixture is TimedVote {
     return commitmentTier2(_account);
   }
 
+  /** Check commitment tier 3 */
   function _commitmentTier3(address _account)
   external
   view

--- a/contracts/test/TimedVoteFixture.sol
+++ b/contracts/test/TimedVoteFixture.sol
@@ -82,6 +82,14 @@ contract TimedVoteFixture is TimedVote {
     return hasVoted(_account, _proposalID);
   }
 
+  /** Check proposal meets quorum */
+  function _meetsQuorum(bytes32 _proposalID)
+  external
+  view
+  returns (bool meets) {
+    return meetsQuorum(_proposalID);
+  }
+
   /** Require proposal closed */
   function _onlyClosedProposal(bytes32 _proposalID)
   external
@@ -239,6 +247,18 @@ contract TimedVoteFixture is TimedVote {
   function _setDissent(bytes32 _proposalID, uint256 _dissent)
   external {
     proposals[_proposalID].dissent = _dissent;
+  }
+
+  /**
+   * Set proposal voting MYB amount
+   * @dev
+   * Assumes extant proposal.
+   * @param _proposalID - Identifier of proposal.
+   * @param _voted - Voting MYB amount.
+   */
+  function _setVoted(bytes32 _proposalID, uint256 _voted)
+  external {
+    proposals[_proposalID].voted = _voted;
   }
 
   /**

--- a/contracts/test/TimedVoteFixture.sol
+++ b/contracts/test/TimedVoteFixture.sol
@@ -6,7 +6,7 @@ contract TimedVoteFixture is TimedVote {
   // -----
   // State
 
-  uint256 timestamp;                            // Artificial now timestamp
+  uint256 private timestamp;                    // Artificial now timestamp
 
   // -----------
   // Constructor

--- a/contracts/test/TimedVoteFixture.sol
+++ b/contracts/test/TimedVoteFixture.sol
@@ -163,49 +163,6 @@ contract TimedVoteFixture is TimedVote {
   }
 
   /**
-   * Advance proposal time by seconds
-   * @param _proposalID - Identifier of proposal to advance.
-   * @param _seconds - Seconds to advance.
-   */
-  function _advanceProposalSeconds(bytes32 _proposalID, uint256 _seconds)
-  public {
-    proposals[_proposalID].start = proposals[_proposalID].start.sub(_seconds);
-  }
-
-  /**
-   * Advance proposal time by minutes
-   * @param _proposalID - Identifier of proposal to advance.
-   * @param _minutes - Minutes to advance.
-   */
-  function _advanceProposalMinutes(bytes32 _proposalID, uint256 _minutes)
-  public {
-    uint256 _seconds = _minutes.mul(60);
-    _advanceProposalSeconds(_proposalID, _seconds);
-  }
-
-  /**
-   * Advance proposal time by hours
-   * @param _proposalID - Identifier of proposal to advance.
-   * @param _hours - Hours to advance.
-   */
-  function _advanceProposalHours(bytes32 _proposalID, uint256 _hours)
-  public {
-    uint256 _minutes = _hours.mul(60);
-    _advanceProposalMinutes(_proposalID, _minutes);
-  }
-
-  /**
-   * Advance proposal time by days
-   * @param _proposalID - Identifier of proposal to advance.
-   * @param _days - Days to advance.
-   */
-  function _advanceProposalDays(bytes32 _proposalID, uint256 _days)
-  external {
-    uint256 _hours = _days.mul(24);
-    _advanceProposalHours(_proposalID, _hours);
-  }
-
-  /**
    * Set account commitment
    * @param _account - Account to set commitment of.
    * @param _amount - MYB commitment amount.

--- a/contracts/test/TimedVoteFixture.sol
+++ b/contracts/test/TimedVoteFixture.sol
@@ -170,7 +170,6 @@ contract TimedVoteFixture is TimedVote {
 
   // --------
   // Override
-  // --------
 
   /**
    * Get artificial current time

--- a/test/TimedVote.js
+++ b/test/TimedVote.js
@@ -292,13 +292,13 @@ contract('TimedVote', () => {
 
     describe('#commitmentOf', () => {
       it('No commitment', async() => {
-        const result = await timedVote.commitmentOf.call(user1);
+        const result = await timedVote.commitmentOf(user1);
         assert.isTrue(BigNumber(result).isEqualTo(0));
       });
 
       it('Commitment', async() => {
         await timedVote._setCommitment(user1, 100);
-        const result = await timedVote.commitmentOf.call(user1);
+        const result = await timedVote.commitmentOf(user1);
         assert.isTrue(BigNumber(result).isEqualTo(100));
       });
     });

--- a/test/TimedVote.js
+++ b/test/TimedVote.js
@@ -13,6 +13,7 @@ const voteDuration = voteDurationDays * 24 * 60 * 60; // In seconds
 const unlockDays = voteDurationDays + 1;
 const closeDays = voteDurationDays + 1;
 const tier2Days = 180 + 1;
+const tier3Days = 365 + 1;
 const validAddress = '0xbaCc40C0Df5E6eC2B0A4e9d1A0F748473F7f8b1a';
 const proposalID =
   '0x0011223344556677889900112233445566778899001122334455667788990011';
@@ -127,6 +128,21 @@ contract('TimedVote', () => {
         await timedVote._timeTravelDays(tier2Days);
         const tier2 = await timedVote._commitmentTier2(user1);
         assert.isTrue(tier2);
+      });
+    });
+
+    describe('~commitmentTier3', () => {
+      it('Prior tier', async() => {
+        await timedVote._setCommitment(user1, 5);
+        const tier3 = await timedVote._commitmentTier3(user1);
+        assert.isFalse(tier3);
+      });
+
+      it('Tier 3', async() => {
+        await timedVote._setCommitment(user1, 5);
+        await timedVote._timeTravelDays(tier3Days);
+        const tier3 = await timedVote._commitmentTier3(user1);
+        assert.isTrue(tier3);
       });
     });
 

--- a/test/TimedVote.js
+++ b/test/TimedVote.js
@@ -234,6 +234,23 @@ contract('TimedVote', () => {
         assert.isTrue(BigNumber(age).isEqualTo(222));
       });
     });
+
+    describe('~weightVote', () => {
+      it('1.0', async() => {
+        const vote = await timedVote._weightVote(10, 100);
+        assert.isTrue(BigNumber(vote).isEqualTo(10));
+      });
+
+      it('1.5', async() => {
+        const vote = await timedVote._weightVote(10, 150);
+        assert.isTrue(BigNumber(vote).isEqualTo(15));
+      });
+
+      it('2.0', async() => {
+        const vote = await timedVote._weightVote(10, 200);
+        assert.isTrue(BigNumber(vote).isEqualTo(20));
+      });
+    });
   });
 
   // --------

--- a/test/TimedVote.js
+++ b/test/TimedVote.js
@@ -447,7 +447,7 @@ contract('TimedVote', () => {
         const { logs: events } = await timedVote.approve(
           proposalID,
           {from: user1}
-        )
+        );
         assert.isAtLeast(events.length, 1);
         const event = events.pop();
         assert.strictEqual(event.event, 'Approve');

--- a/test/TimedVote.js
+++ b/test/TimedVote.js
@@ -9,7 +9,7 @@ const user1 = web3.eth.accounts[0];
 const NULL_ADDRESS = '0x0000000000000000000000000000000000000000';
 const tokenSupply = 180000000000000000000000000;
 const voteDurationDays = 15;
-const voteDuration = voteDurationDays * 24 * 60 * 60; // In seconds
+const voteDuration = voteDurationDays * 24 * 60 * 60; // In second
 const unlockDays = voteDurationDays + 1;
 const closeDays = voteDurationDays + 1;
 const tier2Days = 180 + 1;
@@ -17,6 +17,7 @@ const tier3Days = 365 + 1;
 const tier1Multiplier = 100;
 const tier2Multiplier = 150;
 const tier3Multiplier = 200;
+const quorum = 20; // 20%
 const validAddress = '0xbaCc40C0Df5E6eC2B0A4e9d1A0F748473F7f8b1a';
 const proposalID =
   '0x0011223344556677889900112233445566778899001122334455667788990011';
@@ -47,7 +48,7 @@ contract('TimedVote', () => {
 
   beforeEach(async() => {
     token = await Token.new("MyBit", tokenSupply);
-    timedVote = await TimedVote.new(token.address, voteDuration);
+    timedVote = await TimedVote.new(token.address, voteDuration, quorum);
   });
 
   // ---------
@@ -56,15 +57,15 @@ contract('TimedVote', () => {
 
   describe('Construct', () => {
     it('Succeed', async() => {
-      await TimedVote.new(token.address, voteDuration);
+      await TimedVote.new(token.address, voteDuration, quorum);
     });
 
     it('Fail with null token address', async() => {
-      await rejects(TimedVote.new(NULL_ADDRESS, voteDuration));
+      await rejects(TimedVote.new(NULL_ADDRESS, voteDuration, quorum));
     });
 
     it('Fail with 0 vote duration', async() => {
-      await rejects(TimedVote.new(token.address, 0));
+      await rejects(TimedVote.new(token.address, 0, quorum));
     });
   });
 

--- a/test/TimedVote.js
+++ b/test/TimedVote.js
@@ -149,6 +149,21 @@ contract('TimedVote', () => {
       });
     });
 
+    describe('~hasVoted', () => {
+      it('No vote', async() => {
+        await timedVote._addProposal(proposalID);
+        const voted = await timedVote._hasVoted(user1, proposalID);
+        assert.isFalse(voted);
+      });
+
+      it('Vote', async() => {
+        await timedVote._addProposal(proposalID);
+        await timedVote._setVoted(proposalID, user1);
+        const voted = await timedVote._hasVoted(user1, proposalID);
+        assert.isTrue(voted);
+      });
+    });
+
     describe('#proposalExtant', () => {
       it('Extant', async() => {
         await timedVote._addProposal(proposalID);

--- a/test/TimedVote.js
+++ b/test/TimedVote.js
@@ -308,6 +308,28 @@ contract('TimedVote', () => {
       });
     });
 
+    describe('~onlyIn', () => {
+      it('Accept inner', async() => {
+        await timedVote._onlyIn(5, 0, 10);
+      });
+
+      it('Accept lower limit', async() => {
+        await timedVote._onlyIn(0, 0, 10);
+      });
+
+      it('Accept upper limit', async() => {
+        await timedVote._onlyIn(10, 0, 10);
+      });
+
+      it('Reject below', async() => {
+        await rejects(timedVote._onlyIn(5, 6, 10));
+      });
+
+      it('Reject above', async() => {
+        await rejects(timedVote._onlyIn(11, 6, 10));
+      });
+    });
+
     describe('~onlyNew(proposalID)', () => {
       it('Accept new', async() => {
         await timedVote._onlyNew(proposalID);

--- a/test/TimedVote.js
+++ b/test/TimedVote.js
@@ -341,6 +341,36 @@ contract('TimedVote', () => {
       });
     });
 
+    describe('~totalVotes', () => {
+      it('None', async() => {
+        await timedVote._addProposal(proposalID);
+        const votes = await timedVote._totalVotes(proposalID);
+        assert.isTrue(BigNumber(votes).isEqualTo(0));
+      });
+
+      it('Approval', async() => {
+        await timedVote._addProposal(proposalID);
+        await timedVote._setApproval(proposalID, 50);
+        const votes = await timedVote._totalVotes(proposalID);
+        assert.isTrue(BigNumber(votes).isEqualTo(50));
+      });
+
+      it('Dissent', async() => {
+        await timedVote._addProposal(proposalID);
+        await timedVote._setDissent(proposalID, 50);
+        const votes = await timedVote._totalVotes(proposalID);
+        assert.isTrue(BigNumber(votes).isEqualTo(50));
+      });
+
+      it('Mixed', async() => {
+        await timedVote._addProposal(proposalID);
+        await timedVote._setApproval(proposalID, 50);
+        await timedVote._setDissent(proposalID, 50);
+        const votes = await timedVote._totalVotes(proposalID);
+        assert.isTrue(BigNumber(votes).isEqualTo(100));
+      });
+    });
+
     describe('~votingPercentage', () => {
       it('None', async() => {
         await timedVote._addProposal(proposalID);

--- a/test/TimedVote.js
+++ b/test/TimedVote.js
@@ -162,6 +162,21 @@ contract('TimedVote', () => {
         assert.isTrue(BigNumber(age).isEqualTo(222));
       });
     });
+
+    describe('~proposalAge', () => {
+      it('Birth', async() => {
+        await timedVote._addProposal(proposalID);
+        const age = await timedVote._proposalAge(proposalID);
+        assert.isTrue(BigNumber(age).isEqualTo(0));
+      });
+
+      it('Terrible 2s', async() => {
+        await timedVote._addProposal(proposalID);
+        await timedVote._timeTravelSeconds(222);
+        const age = await timedVote._proposalAge(proposalID);
+        assert.isTrue(BigNumber(age).isEqualTo(222));
+      });
+    });
   });
 
   // --------

--- a/test/TimedVote.js
+++ b/test/TimedVote.js
@@ -12,6 +12,7 @@ const voteDurationDays = 15;
 const voteDuration = voteDurationDays * 24 * 60 * 60; // In seconds
 const unlockDays = voteDurationDays + 1;
 const closeDays = voteDurationDays + 1;
+const tier2Days = 180 + 1;
 const validAddress = '0xbaCc40C0Df5E6eC2B0A4e9d1A0F748473F7f8b1a';
 const proposalID =
   '0x0011223344556677889900112233445566778899001122334455667788990011';
@@ -111,6 +112,21 @@ contract('TimedVote', () => {
         await timedVote._timeTravelDays(unlockDays);
         const locked = await timedVote._commitmentLocked(user1);
         assert.isFalse(locked);
+      });
+    });
+
+    describe('~commitmentTier2', () => {
+      it('Prior tier', async() => {
+        await timedVote._setCommitment(user1, 5);
+        const tier2 = await timedVote._commitmentTier2(user1);
+        assert.isFalse(tier2);
+      });
+
+      it('Tier 2', async() => {
+        await timedVote._setCommitment(user1, 5);
+        await timedVote._timeTravelDays(tier2Days);
+        const tier2 = await timedVote._commitmentTier2(user1);
+        assert.isTrue(tier2);
       });
     });
 

--- a/test/TimedVote.js
+++ b/test/TimedVote.js
@@ -177,6 +177,32 @@ contract('TimedVote', () => {
       });
     });
 
+    describe('~meetsQuorum', () => {
+      it('Over', async() => {
+        const amount = (quorum + 10) / 100 * tokenSupply;
+        await timedVote._addProposal(proposalID);
+        await timedVote._setVoted(proposalID, amount);
+        const meets = await timedVote._meetsQuorum(proposalID);
+        assert.isTrue(meets);
+      });
+
+      it('Under', async() => {
+        const amount = (quorum - 10) / 100 * tokenSupply;
+        await timedVote._addProposal(proposalID);
+        await timedVote._setVoted(proposalID, amount);
+        const meets = await timedVote._meetsQuorum(proposalID);
+        assert.isFalse(meets);
+      });
+
+      it('At', async() => {
+        const amount = quorum / 100 * tokenSupply;
+        await timedVote._addProposal(proposalID);
+        await timedVote._setVoted(proposalID, amount);
+        const meets = await timedVote._meetsQuorum(proposalID);
+        assert.isTrue(meets);
+      });
+    });
+
     describe('#proposalExtant', () => {
       it('Extant', async() => {
         await timedVote._addProposal(proposalID);

--- a/test/TimedVote.js
+++ b/test/TimedVote.js
@@ -319,6 +319,19 @@ contract('TimedVote', () => {
       });
     });
 
+    describe('~onlyOneVote', () => {
+      it('Accept first', async() => {
+        await timedVote._addProposal(proposalID);
+        await timedVote._onlyOneVote(proposalID, user1);
+      });
+
+      it('Reject subsequent', async() => {
+        await timedVote._addProposal(proposalID);
+        await timedVote._setVoted(proposalID, user1);
+        await rejects(timedVote._onlyOneVote(proposalID, user1));
+      });
+    });
+
     describe('~onlyOpen(proposal)', () => {
       it('Accept open', async() => {
         await timedVote._addProposal(proposalID);

--- a/test/TimedVote.js
+++ b/test/TimedVote.js
@@ -582,6 +582,29 @@ contract('TimedVote', () => {
       });
     });
 
+    describe('~onlyMeetsQuorum', () => {
+      it('Accept over', async() => {
+        const amount = (quorum + 10) / 100 * tokenSupply;
+        await timedVote._addProposal(proposalID);
+        await timedVote._setVoted(proposalID, amount);
+        await timedVote._onlyMeetsQuorum(proposalID);
+      });
+
+      it('Accept at', async() => {
+        const amount = quorum / 100 * tokenSupply;
+        await timedVote._addProposal(proposalID);
+        await timedVote._setVoted(proposalID, amount);
+        await timedVote._onlyMeetsQuorum(proposalID);
+      });
+
+      it('Reject under', async() => {
+        const amount = (quorum - 10) / 100 * tokenSupply;
+        await timedVote._addProposal(proposalID);
+        await timedVote._setVoted(proposalID, amount);
+        await rejects(timedVote._onlyMeetsQuorum(proposalID));
+      });
+    });
+
     describe('~onlyNew(proposalID)', () => {
       it('Accept new', async() => {
         await timedVote._onlyNew(proposalID);

--- a/test/TimedVote.js
+++ b/test/TimedVote.js
@@ -108,7 +108,7 @@ contract('TimedVote', () => {
 
       it('Unlocked', async() => {
         await timedVote._setCommitment(user1, 5);
-        await timedVote._advanceCommitmentDays(user1, unlockDays);
+        await timedVote._timeTravelDays(unlockDays);
         const locked = await timedVote._commitmentLocked(user1);
         assert.isFalse(locked);
       });
@@ -136,7 +136,7 @@ contract('TimedVote', () => {
 
       it('Closed', async() => {
         await timedVote._addProposal(proposalID);
-        await timedVote._advanceProposalDays(proposalID, closeDays);
+        await timedVote._timeTravelDays(closeDays);
         const open = await timedVote._proposalOpen(proposalID);
         assert.isFalse(open);
       });
@@ -157,7 +157,7 @@ contract('TimedVote', () => {
 
       it('Terrible 2s', async() => {
         await timedVote._setCommitment(user1, 5);
-        await timedVote._advanceCommitmentSeconds(user1, 222);
+        await timedVote._timeTravelSeconds(222);
         const age = await timedVote._commitmentAge(user1);
         assert.isTrue(BigNumber(age).isEqualTo(222));
       });
@@ -172,7 +172,7 @@ contract('TimedVote', () => {
     describe('~onlyClosed(proposal)', () => {
       it('Accept closed', async() => {
         await timedVote._addProposal(proposalID);
-        await timedVote._advanceProposalDays(proposalID, closeDays);
+        await timedVote._timeTravelDays(closeDays);
         await timedVote._onlyClosedProposal(proposalID);
       });
 
@@ -223,7 +223,7 @@ contract('TimedVote', () => {
 
       it('Reject closed', async() => {
         await timedVote._addProposal(proposalID);
-        await timedVote._advanceProposalDays(proposalID, closeDays);
+        await timedVote._timeTravelDays(closeDays);
         await rejects(timedVote._onlyOpenProposal(proposalID));
       });
     });
@@ -256,7 +256,7 @@ contract('TimedVote', () => {
     describe('~onlyUnlocked', () => {
       it('Accept unlocked', async() => {
         await timedVote._setCommitment(user1, 5);
-        await timedVote._advanceCommitmentDays(user1, unlockDays);
+        await timedVote._timeTravelDays(unlockDays);
         await timedVote._onlyUnlocked();
       });
 
@@ -375,7 +375,7 @@ contract('TimedVote', () => {
         await token.transfer(user1, 100);
         await token.approve(timedVote.address, 100, {from: user1});
         await timedVote.commit(100);
-        await timedVote._advanceCommitmentDays(user1, unlockDays);
+        await timedVote._timeTravelDays(unlockDays);
         await timedVote.withdraw();
       });
 
@@ -383,7 +383,7 @@ contract('TimedVote', () => {
         await token.transfer(user1, 100);
         await token.approve(timedVote.address, 100, {from: user1});
         await timedVote.commit(100);
-        await timedVote._advanceCommitmentDays(user1, unlockDays);
+        await timedVote._timeTravelDays(unlockDays);
         const { logs: events } = await timedVote.withdraw();
         assert.isAtLeast(events.length, 1);
         const event = events.pop();

--- a/test/TimedVote.js
+++ b/test/TimedVote.js
@@ -203,6 +203,38 @@ contract('TimedVote', () => {
       });
     });
 
+    describe('~meetsThreshold', () => {
+      it('Over', async() => {
+        const approval = 900;
+        const dissent = 100;
+        await timedVote._addProposal(proposalID);
+        await timedVote._setApproval(proposalID, approval);
+        await timedVote._setDissent(proposalID, dissent);
+        const meets = await timedVote._meetsThreshold(proposalID);
+        assert.isTrue(meets);
+      });
+
+      it('Under', async() => {
+        const approval = 200;
+        const dissent = 800;
+        await timedVote._addProposal(proposalID);
+        await timedVote._setApproval(proposalID, approval);
+        await timedVote._setDissent(proposalID, dissent);
+        const meets = await timedVote._meetsThreshold(proposalID);
+        assert.isFalse(meets);
+      });
+
+      it('At', async() => {
+        const approval = 510;
+        const dissent = 490;
+        await timedVote._addProposal(proposalID);
+        await timedVote._setApproval(proposalID, approval);
+        await timedVote._setDissent(proposalID, dissent);
+        const meets = await timedVote._meetsThreshold(proposalID);
+        assert.isTrue(meets);
+      });
+    });
+
     describe('#proposalExtant', () => {
       it('Extant', async() => {
         await timedVote._addProposal(proposalID);

--- a/test/TimedVote.js
+++ b/test/TimedVote.js
@@ -248,6 +248,19 @@ contract('TimedVote', () => {
       });
     });
 
+    describe('#commitmentOf', () => {
+      it('No commitment', async() => {
+        const result = await timedVote.commitmentOf.call(user1);
+        assert.isTrue(BigNumber(result).isEqualTo(0));
+      });
+
+      it('Commitment', async() => {
+        await timedVote._setCommitment(user1, 100);
+        const result = await timedVote.commitmentOf.call(user1);
+        assert.isTrue(BigNumber(result).isEqualTo(100));
+      });
+    });
+
     describe('#multiplierOf', () => {
       it('Tier 1', async() => {
         await timedVote._setCommitment(user1, 5);
@@ -534,19 +547,6 @@ contract('TimedVote', () => {
         assert.strictEqual(event.event, 'Commit');
         assert.strictEqual(event.args.account, user1);
         assert.isTrue(BigNumber(event.args.value).isEqualTo(100));
-      });
-    });
-
-    describe('#commitmentOf', () => {
-      it('No commitment', async() => {
-        const result = await timedVote.commitmentOf.call(user1);
-        assert.isTrue(BigNumber(result).isEqualTo(0));
-      });
-
-      it('Commitment', async() => {
-        await timedVote._setCommitment(user1, 100);
-        const result = await timedVote.commitmentOf.call(user1);
-        assert.isTrue(BigNumber(result).isEqualTo(100));
       });
     });
 

--- a/test/TimedVote.js
+++ b/test/TimedVote.js
@@ -14,6 +14,9 @@ const unlockDays = voteDurationDays + 1;
 const closeDays = voteDurationDays + 1;
 const tier2Days = 180 + 1;
 const tier3Days = 365 + 1;
+const tier1Multiplier = 100;
+const tier2Multiplier = 150;
+const tier3Multiplier = 200;
 const validAddress = '0xbaCc40C0Df5E6eC2B0A4e9d1A0F748473F7f8b1a';
 const proposalID =
   '0x0011223344556677889900112233445566778899001122334455667788990011';
@@ -192,6 +195,28 @@ contract('TimedVote', () => {
         await timedVote._timeTravelSeconds(222);
         const age = await timedVote._commitmentAge(user1);
         assert.isTrue(BigNumber(age).isEqualTo(222));
+      });
+    });
+
+    describe('#multiplierOf', () => {
+      it('Tier 1', async() => {
+        await timedVote._setCommitment(user1, 5);
+        const multiplier = await timedVote.multiplierOf(user1);
+        assert.isTrue(BigNumber(multiplier).isEqualTo(tier1Multiplier));
+      });
+
+      it('Tier 2', async() => {
+        await timedVote._setCommitment(user1, 5);
+        await timedVote._timeTravelDays(tier2Days);
+        const multiplier = await timedVote.multiplierOf(user1);
+        assert.isTrue(BigNumber(multiplier).isEqualTo(tier2Multiplier));
+      });
+
+      it('Tier 3', async() => {
+        await timedVote._setCommitment(user1, 5);
+        await timedVote._timeTravelDays(tier3Days);
+        const multiplier = await timedVote.multiplierOf(user1);
+        assert.isTrue(BigNumber(multiplier).isEqualTo(tier3Multiplier));
       });
     });
 

--- a/test/TimedVote.js
+++ b/test/TimedVote.js
@@ -18,6 +18,7 @@ const tier1Multiplier = 100;
 const tier2Multiplier = 150;
 const tier3Multiplier = 200;
 const quorum = 20; // 20%
+const threshold = 51; // 51%
 const validAddress = '0xbaCc40C0Df5E6eC2B0A4e9d1A0F748473F7f8b1a';
 const proposalID =
   '0x0011223344556677889900112233445566778899001122334455667788990011';
@@ -48,7 +49,12 @@ contract('TimedVote', () => {
 
   beforeEach(async() => {
     token = await Token.new("MyBit", tokenSupply);
-    timedVote = await TimedVote.new(token.address, voteDuration, quorum);
+    timedVote = await TimedVote.new(
+      token.address,
+      voteDuration,
+      quorum,
+      threshold
+    );
   });
 
   // ---------
@@ -57,15 +63,20 @@ contract('TimedVote', () => {
 
   describe('Construct', () => {
     it('Succeed', async() => {
-      await TimedVote.new(token.address, voteDuration, quorum);
+      await TimedVote.new(token.address, voteDuration, quorum, threshold);
     });
 
     it('Fail with null token address', async() => {
-      await rejects(TimedVote.new(NULL_ADDRESS, voteDuration, quorum));
+      await rejects(TimedVote.new(
+        NULL_ADDRESS,
+        voteDuration,
+        quorum,
+        threshold
+      ));
     });
 
     it('Fail with 0 vote duration', async() => {
-      await rejects(TimedVote.new(token.address, 0, quorum));
+      await rejects(TimedVote.new(token.address, 0, quorum, threshold));
     });
   });
 

--- a/test/TimedVote.js
+++ b/test/TimedVote.js
@@ -205,11 +205,34 @@ contract('TimedVote', () => {
     });
   });
 
-  // -----
-  // Value
-  // -----
+  // ----------
+  // Pure Value
+  // ----------
 
-  describe('Value', () => {
+  describe('Pure Value', () => {
+    describe('~weightVote', () => {
+      it('1.0', async() => {
+        const vote = await timedVote._weightVote(10, 100);
+        assert.isTrue(BigNumber(vote).isEqualTo(10));
+      });
+
+      it('1.5', async() => {
+        const vote = await timedVote._weightVote(10, 150);
+        assert.isTrue(BigNumber(vote).isEqualTo(15));
+      });
+
+      it('2.0', async() => {
+        const vote = await timedVote._weightVote(10, 200);
+        assert.isTrue(BigNumber(vote).isEqualTo(20));
+      });
+    });
+  });
+
+  // ----------
+  // View Value
+  // ----------
+
+  describe('View Value', () => {
     describe('~commitmentAge', () => {
       it('Birth', async() => {
         await timedVote._setCommitment(user1, 5);
@@ -259,23 +282,6 @@ contract('TimedVote', () => {
         await timedVote._timeTravelSeconds(222);
         const age = await timedVote._proposalAge(proposalID);
         assert.isTrue(BigNumber(age).isEqualTo(222));
-      });
-    });
-
-    describe('~weightVote', () => {
-      it('1.0', async() => {
-        const vote = await timedVote._weightVote(10, 100);
-        assert.isTrue(BigNumber(vote).isEqualTo(10));
-      });
-
-      it('1.5', async() => {
-        const vote = await timedVote._weightVote(10, 150);
-        assert.isTrue(BigNumber(vote).isEqualTo(15));
-      });
-
-      it('2.0', async() => {
-        const vote = await timedVote._weightVote(10, 200);
-        assert.isTrue(BigNumber(vote).isEqualTo(20));
       });
     });
   });

--- a/test/TimedVote.js
+++ b/test/TimedVote.js
@@ -210,6 +210,48 @@ contract('TimedVote', () => {
   // ----------
 
   describe('Pure Value', () => {
+    describe('~percentage', () => {
+      it('0%', async() => {
+        const percent = await timedVote._percentage(0, 1000);
+        assert.isTrue(BigNumber(percent).isEqualTo(0));
+      });
+
+      it('1%', async() => {
+        const percent = await timedVote._percentage(10, 1000);
+        assert.isTrue(BigNumber(percent).isEqualTo(1));
+      });
+
+      it('20%', async() => {
+        const percent = await timedVote._percentage(200, 1000);
+        assert.isTrue(BigNumber(percent).isEqualTo(20));
+      });
+
+      it('50%', async() => {
+        const percent = await timedVote._percentage(500, 1000);
+        assert.isTrue(BigNumber(percent).isEqualTo(50));
+      });
+
+      it('100%', async() => {
+        const percent = await timedVote._percentage(1000, 1000);
+        assert.isTrue(BigNumber(percent).isEqualTo(100));
+      });
+
+      it('200%', async() => {
+        const percent = await timedVote._percentage(2000, 1000);
+        assert.isTrue(BigNumber(percent).isEqualTo(200));
+      });
+
+      it('Approximate', async() => {
+        const percent = await timedVote._percentage(57, 599);
+        assert.isTrue(BigNumber(percent).isEqualTo(9)); // Exact ~9.5
+      });
+
+      it('Approximately none', async() => {
+        const percent = await timedVote._percentage(57, 55555);
+        assert.isTrue(BigNumber(percent).isEqualTo(0)); // Exact ~0.1
+      });
+    });
+
     describe('~weightVote', () => {
       it('1.0', async() => {
         const vote = await timedVote._weightVote(10, 100);

--- a/test/TimedVote.js
+++ b/test/TimedVote.js
@@ -306,7 +306,7 @@ contract('TimedVote', () => {
       it('Reject nonextant', async() => {
         await rejects(timedVote._onlyExtant(proposalID));
       });
-    })
+    });
 
     describe('~onlyNew(proposalID)', () => {
       it('Accept new', async() => {

--- a/test/TimedVote.js
+++ b/test/TimedVote.js
@@ -582,29 +582,6 @@ contract('TimedVote', () => {
       });
     });
 
-    describe('~onlyMeetsQuorum', () => {
-      it('Accept over', async() => {
-        const amount = (quorum + 10) / 100 * tokenSupply;
-        await timedVote._addProposal(proposalID);
-        await timedVote._setVoted(proposalID, amount);
-        await timedVote._onlyMeetsQuorum(proposalID);
-      });
-
-      it('Accept at', async() => {
-        const amount = quorum / 100 * tokenSupply;
-        await timedVote._addProposal(proposalID);
-        await timedVote._setVoted(proposalID, amount);
-        await timedVote._onlyMeetsQuorum(proposalID);
-      });
-
-      it('Reject under', async() => {
-        const amount = (quorum - 10) / 100 * tokenSupply;
-        await timedVote._addProposal(proposalID);
-        await timedVote._setVoted(proposalID, amount);
-        await rejects(timedVote._onlyMeetsQuorum(proposalID));
-      });
-    });
-
     describe('~onlyNew(proposalID)', () => {
       it('Accept new', async() => {
         await timedVote._onlyNew(proposalID);

--- a/test/TimedVote.js
+++ b/test/TimedVote.js
@@ -276,6 +276,30 @@ contract('TimedVote', () => {
   // ----------
 
   describe('View Value', () => {
+    describe('~approvalPercentage', () => {
+      it('0%', async() => {
+        await timedVote._addProposal(proposalID);
+        await timedVote._setDissent(proposalID, 1000);
+        const percent = await timedVote._approvalPercentage(proposalID);
+        assert.isTrue(BigNumber(percent).isEqualTo(0));
+      });
+
+      it('50%', async() => {
+        await timedVote._addProposal(proposalID);
+        await timedVote._setApproval(proposalID, 500);
+        await timedVote._setDissent(proposalID, 500);
+        const percent = await timedVote._approvalPercentage(proposalID);
+        assert.isTrue(BigNumber(percent).isEqualTo(50));
+      });
+
+      it('100%', async() => {
+        await timedVote._addProposal(proposalID);
+        await timedVote._setApproval(proposalID, 1000);
+        const percent = await timedVote._approvalPercentage(proposalID);
+        assert.isTrue(BigNumber(percent).isEqualTo(100));
+      });
+    });
+
     describe('~commitmentAge', () => {
       it('Birth', async() => {
         await timedVote._setCommitment(user1, 5);

--- a/test/TimedVote.js
+++ b/test/TimedVote.js
@@ -171,7 +171,7 @@ contract('TimedVote', () => {
 
       it('Vote', async() => {
         await timedVote._addProposal(proposalID);
-        await timedVote._setVoted(proposalID, user1);
+        await timedVote._setVoter(proposalID, user1);
         const voted = await timedVote._hasVoted(user1, proposalID);
         assert.isTrue(voted);
       });
@@ -543,7 +543,7 @@ contract('TimedVote', () => {
 
       it('Reject subsequent', async() => {
         await timedVote._addProposal(proposalID);
-        await timedVote._setVoted(proposalID, user1);
+        await timedVote._setVoter(proposalID, user1);
         await rejects(timedVote._onlyOneVote(proposalID, user1));
       });
     });
@@ -645,7 +645,7 @@ contract('TimedVote', () => {
         await timedVote._setCommitment(user1, 5);
         await timedVote._timeTravelDays(unlockDays);
         await timedVote._addProposal(proposalID);
-        await timedVote._setVoted(proposalID, user1);
+        await timedVote._setVoter(proposalID, user1);
         await rejects(timedVote.approve(proposalID, {from: user1}));
       });
 
@@ -743,7 +743,7 @@ contract('TimedVote', () => {
         await timedVote._setCommitment(user1, 5);
         await timedVote._timeTravelDays(unlockDays);
         await timedVote._addProposal(proposalID);
-        await timedVote._setVoted(proposalID, user1);
+        await timedVote._setVoter(proposalID, user1);
         await rejects(timedVote.decline(proposalID, {from: user1}));
       });
 

--- a/test/TimedVote.js
+++ b/test/TimedVote.js
@@ -510,6 +510,64 @@ contract('TimedVote', () => {
       });
     });
 
+    describe('#decline', () => {
+      it('Fail without commitment', async() => {
+        await timedVote._addProposal(proposalID);
+        await rejects(timedVote.decline(proposalID, {from: user1}));
+      });
+
+      it('Fail with locked commitment', async() => {
+        await timedVote._setCommitment(user1, 5);
+        await timedVote._addProposal(proposalID);
+        await rejects(timedVote.decline(proposalID, {from: user1}));
+      });
+
+      it('Fail with missing proposal', async() => {
+        await timedVote._setCommitment(user1, 5);
+        await timedVote._timeTravelDays(unlockDays);
+        await rejects(timedVote.decline(proposalID, {from: user1}));
+      });
+
+      it('Fail with closed proposal', async() => {
+        await timedVote._setCommitment(user1, 5);
+        await timedVote._timeTravelDays(unlockDays);
+        await timedVote._addProposal(proposalID);
+        await timedVote._timeTravelDays(closeDays);
+        await rejects(timedVote.decline(proposalID, {from: user1}));
+      });
+
+      it('Fail on plural vote', async() => {
+        await timedVote._setCommitment(user1, 5);
+        await timedVote._timeTravelDays(unlockDays);
+        await timedVote._addProposal(proposalID);
+        await timedVote._setVoted(proposalID, user1);
+        await rejects(timedVote.decline(proposalID, {from: user1}));
+      });
+
+      it('Succeed', async() => {
+        await timedVote._setCommitment(user1, 5);
+        await timedVote._timeTravelDays(unlockDays);
+        await timedVote._addProposal(proposalID);
+        await timedVote.decline(proposalID, {from: user1});
+      });
+
+      it('Emit Decline', async() => {
+        await timedVote._setCommitment(user1, 5);
+        await timedVote._timeTravelDays(unlockDays);
+        await timedVote._addProposal(proposalID);
+        const { logs: events } = await timedVote.decline(
+          proposalID,
+          {from: user1}
+        );
+        assert.isAtLeast(events.length, 1);
+        const event = events.pop();
+        assert.strictEqual(event.event, 'Decline');
+        assert.strictEqual(event.args.proposalID, proposalID);
+        assert.strictEqual(event.args.account, user1);
+        assert.isTrue(BigNumber(event.args.vote).isEqualTo(5));
+      });
+    });
+
     describe('#propose', () => {
       it('Fail with extant ID', async() => {
         await timedVote._addProposal(proposalID);


### PR DESCRIPTION
Adds a `TimedVote` smart contract implementing decentralised voting. Aiming for fulfillment of MyBitFoundation/MyBit-DDF.website#68.

Anyone can create a proposal. MYB holders can commit their tokens to voting. There's a lock period of the vote duration during which a commitment cannot vote or be withdrawn. A commitment can approve or decline any proposal. Votes are weighted by commit time: 1.0 first 6 months, 1.5 to 365 days, 2.0 after that. When voting closes a proposal passes if a quorum of total MYB supply voted and approval meets the threshold.

Vote duration, quorum, and approval threshold are configurable in the constructor. Tiered vote weighting configuration is in constants (I could put that in constructor params if it's better). I've tried to include comprehensive tests.

Not sure if this is right:
* Should people be able to vote immediately after committing?
* I have it depending on a static MYB total supply. Is that safe to depend on?

The interface is like this:

| Method | Description |
| ------ | ----------- |
| `accountCommitted` | Check whether account has an active committed. |
| `approve` | Approve an open proposal. |
| `commit` | Commit MYB to voting. |
| `commitmentOf` | Get the committed MYB amount of an account. |
| `decline` | Decline an open proposal. |
| `multiplierOf` | Get the vote weight of an account. |
| `proposalExtant` | Check whether a proposal ID exists. |
| `propose` | Create a new proposal. |
| `result` | Check result of a closed proposal. |
| `status` | Get status of a proposal. Enables watching ongoing voting activity. |
| `withdraw` | Withdraw committed MYB. |

There are a few events emitted:

| Event | Description |
| ----- | ----------- |
| `Approve` | An approve vote was cast on a proposal. |
| `Commit` | MYB was committed to voting. |
| `Decline` | A decline vote was cast on a proposal. |
| `Propose` | A new proposal was created. |
| `Withdraw` | Committed MYB was withdrawn. |