### PR TITLE
Changes to AssetGoverance, Timevote, Escrow

### DIFF
--- a/contracts/access/ERC20Burner.sol
+++ b/contracts/access/ERC20Burner.sol
@@ -21,7 +21,7 @@ contract ERC20Burner {
   public {
     database = DBInterface(_database);
     events = Events(_events);
-    token = BurnableERC20(database.addressStorage(keccak256(abi.encodePacked("platformToken"))));
+    token = BurnableERC20(database.addressStorage(keccak256(abi.encodePacked("tokenAddress", keccak256(abi.encodePacked("platformAssetID"))))));
     require(address(token) != address(0));
   }
 

--- a/contracts/database/API.sol
+++ b/contracts/database/API.sol
@@ -41,35 +41,35 @@ contract API {
 
 
   // @notice returns the amount of tokens unlocked and free to spend for _ser
-  function getNumTokensAvailable(bytes32 _assetID, address _investor)
+  function getNumTokensAvailable(bytes32 _proposalID, address _investor)
   public
   view
   returns (uint) {
-    uint amountLocked = database.uintStorage(keccak256(abi.encodePacked("tokensLocked", _assetID, _investor)));
-    address assetToken = database.addressStorage(keccak256(abi.encodePacked("tokenAddress", _assetID)));
+    address assetToken = database.addressStorage(keccak256(abi.encodePacked("tokenAddress", _proposalID)));
+    uint amountLocked = database.uintStorage(keccak256(abi.encodePacked("tokensLocked", assetToken, _investor)));
     uint balance = TokenView(assetToken).balanceOf(_investor);
     return balance.sub(amountLocked);
   }
 
-  function getInvestorVotes(bytes32 _executionID, address _investor)
+  function getInvestorVotes(bytes32 _proposalID, address _investor)
   public
   view
   returns (uint) {
-    return database.uintStorage(keccak256(abi.encodePacked("investorVotes", _executionID, _investor)));
+    return database.uintStorage(keccak256(abi.encodePacked("investorVotes", _proposalID, _investor)));
   }
 
-  function getTotalVotes(bytes32 _executionID)
+  function getTotalVotes(bytes32 _proposalID)
   public
   view
   returns (uint) {
-  return database.uintStorage(keccak256(abi.encodePacked("voteTotal", _executionID)));
+  return database.uintStorage(keccak256(abi.encodePacked("voteTotal", _proposalID)));
   }
 
-  function getCurrentConsensus(bytes32 _executionID, address _assetToken)
+  function getCurrentConsensus(bytes32 _proposalID, address _assetToken)
   public
   view
   returns (uint) {
-    uint totalVotes = getTotalVotes(_executionID);
+    uint totalVotes = getTotalVotes(_proposalID);
     return ( ( (totalVotes * 100) * scalingFactor) / TokenView(_assetToken).totalSupply() / scalingFactor);
   }
 
@@ -80,7 +80,7 @@ contract API {
     return keccak256(abi.encodePacked(_assetID, _oldAssetManager, _newAssetManager, _amount, _burn));
   }
 
-  function getExecutionID(address _executingContract, bytes32 _assetID, bytes4 _methodID, bytes32 _parameterHash)
+  function getProposalID(address _executingContract, bytes32 _assetID, bytes4 _methodID, bytes32 _parameterHash)
   public
   pure
   returns (bytes32) {
@@ -126,6 +126,13 @@ contract API {
   returns(bytes32) {
     bytes32 assetID = database.bytes32Storage(keccak256(abi.encodePacked("assetTokenID", _tokenAddress)));
     return assetID;
+  }
+
+  function getPlatformAssetID()
+  external
+  pure
+  returns(bytes32){
+    return keccak256(abi.encodePacked("platformAssetID"));
   }
 
   function getAssetAddress(bytes32 _assetID)
@@ -292,7 +299,7 @@ contract API {
   public
   view
   returns(address) {
-    address tokenAddress = database.addressStorage(keccak256(abi.encodePacked("platformToken")));
+    address tokenAddress = database.addressStorage(keccak256(abi.encodePacked("tokenAddress", keccak256(abi.encodePacked("platformAssetID")))));
     return tokenAddress;
   }
 

--- a/contracts/ecosystem/PlatformFunds.sol
+++ b/contracts/ecosystem/PlatformFunds.sol
@@ -29,6 +29,8 @@ contract PlatformFunds {
   function setPlatformToken(address _tokenAddress)
   external
   onlyOwner {
+    //@dev Set the address for the platform token, using keccak256(abi.encodePacked("platformAssetID")) as the assetID for the platform
+    database.setAddress(keccak256(abi.encodePacked("tokenAddress", keccak256(abi.encodePacked("platformAssetID")))), _tokenAddress);
     database.setAddress(keccak256(abi.encodePacked("platformToken")), _tokenAddress);
     //emit LogPlatformToken(_tokenAddress);
     events.registration('Platform token', _tokenAddress);

--- a/contracts/ecosystem/Staking.sol
+++ b/contracts/ecosystem/Staking.sol
@@ -40,7 +40,7 @@
   returns (bool) {
     bytes32 agreementHash = keccak256(abi.encodePacked(_requester, _assetID, _amount, _sharePercentage));
     require (database.bytes32Storage(_assetID) == agreementHash);
-    ERC20 stakingToken = ERC20(database.addressStorage(keccak256(abi.encodePacked("platformToken"))));
+    ERC20 stakingToken = ERC20(database.addressStorage(keccak256(abi.encodePacked("tokenAddress", keccak256(abi.encodePacked("platformAssetID"))))));
     MintableDistribution distributionToken = MintableDistribution(database.addressStorage(keccak256(abi.encodePacked("stakingMint", _assetID))));
     bytes32 finalAgreement = keccak256(abi.encodePacked(msg.sender, agreementHash));
     database.setBytes32(_assetID, finalAgreement);

--- a/contracts/interfaces/VotingInterface.sol
+++ b/contracts/interfaces/VotingInterface.sol
@@ -1,0 +1,7 @@
+pragma solidity ^0.4.24;
+
+interface VotingInterface {
+  function result(bytes32 _proposalID) external view returns (bool passed);
+
+  function proposalExtant(bytes32 _proposalID) external view returns (bool extant);
+}

--- a/contracts/ownership/AssetGovernance.sol
+++ b/contracts/ownership/AssetGovernance.sol
@@ -2,6 +2,7 @@ pragma solidity 0.4.24;
 
 import "../math/SafeMath.sol";
 import "../database/Events.sol";
+import "../interfaces/VotingInterface.sol";
 interface Burner { function burnEscrow(bytes32 _assetID) external returns (bool); }
 interface Escrow { function unlockEscrow(bytes32 _assetID) external returns (bool); }
 interface DB {
@@ -9,6 +10,7 @@ interface DB {
   function uintStorage(bytes32 _key) external view returns (uint);
   function boolStorage(bytes32 _key) external view returns (bool);
   function setUint(bytes32 _key, uint _value) external;
+  function setAddress(bytes32 _key, address _value) external;
 }
 interface TokenView {
   function totalSupply() external view returns (uint);
@@ -18,7 +20,7 @@ interface TokenView {
 // @title A contract to manage the governance of assets on the platform
 // @author Kyle Dewhurst, MyBit Foundation
 // @notice All token holders of an asset can vote here
-contract AssetGovernance {
+contract AssetGovernance is VotingInterface{
   using SafeMath for uint256;
 
   DB public database;
@@ -33,19 +35,33 @@ contract AssetGovernance {
     events = Events(_events);
   }
 
+  function propose(address _executingContract, bytes32 _assetID, bytes4 _methodID, bytes32 _parameterHash)
+  public
+  onlyNew(keccak256(abi.encodePacked(_executingContract, _assetID, _methodID, _parameterHash))){
+    bytes32 proposalID = keccak256(abi.encodePacked(_executingContract, _assetID, _methodID, _parameterHash));
+    address tokenAddress = database.addressStorage(keccak256(abi.encodePacked("tokenAddress", _assetID)));
+    database.setAddress(keccak256(abi.encodePacked("tokenAddress", proposalID)), tokenAddress);
+    //emit Propose(msg.sender, proposalID);
+  }
+
+  function getProposalID(address _executingContract, bytes32 _assetID, bytes4 _methodID, bytes32 _parameterHash)
+  external
+  pure
+  returns(bytes32){
+    return(keccak256(abi.encodePacked(_executingContract, _assetID, _methodID, _parameterHash)));
+  }
 
   // @param (bytes32) _parameterHash = The hash of the exact parameter to be called for function...
   // @dev ie sha3(_assetID) or sha3(_assetID, someAddress)
-  function voteForExecution(address _executingContract, bytes32 _assetID, bytes4 _methodID, bytes32 _parameterHash, uint _amountToLock)
+  function voteForExecution(bytes32 _proposalID, uint _amountToLock)
   external
-  validAsset(_assetID)
+  validProposal(_proposalID)
   returns (bool) {
-    bytes32 executionID = keccak256(abi.encodePacked(_executingContract, _assetID, _methodID, _parameterHash));
-    bytes32 numVotesID = keccak256(abi.encodePacked("voteTotal", executionID));
-    bytes32 investorVotesID = keccak256(abi.encodePacked("investorVotes", executionID, msg.sender));
+    bytes32 numVotesID = keccak256(abi.encodePacked("voteTotal", _proposalID));
+    bytes32 investorVotesID = keccak256(abi.encodePacked("investorVotes", _proposalID, msg.sender));
     uint256 numVotes = database.uintStorage(numVotesID);
     uint256 investorVotes = database.uintStorage(investorVotesID);
-    require(lockTokens(_assetID, msg.sender, _amountToLock), "unable to lock tokens");
+    require(lockTokens(_proposalID, msg.sender, _amountToLock), "unable to lock tokens");
     database.setUint(numVotesID, numVotes.add(_amountToLock));
     database.setUint(investorVotesID, investorVotes.add(_amountToLock));
     return true;
@@ -54,20 +70,20 @@ contract AssetGovernance {
 
   // @notice unlock tokens, removing them from the vote
   // @dev _executionID should be looked up in event logs. it is equal to sha3(_assetID, _methodID, _parameterHash)
-  function unlockToken(address _executingContract, bytes32 _assetID, bytes4 _methodID, bytes32 _parameterHash, uint _amountToUnlock)
+  function unlockToken(bytes32 _proposalID, uint _amountToUnlock)
   external
-  validAsset(_assetID)
+  validProposal(_proposalID)
   returns (bool) {
-    bytes32 executionID = keccak256(abi.encodePacked(_executingContract, _assetID, _methodID, _parameterHash));
-    bytes32 voteTotalID = keccak256(abi.encodePacked("voteTotal", executionID));
-    bytes32 investorVotesID = keccak256(abi.encodePacked("investorVotes", executionID, msg.sender));
+    bytes32 voteTotalID = keccak256(abi.encodePacked("voteTotal", _proposalID));
+    bytes32 investorVotesID = keccak256(abi.encodePacked("investorVotes", _proposalID, msg.sender));
     uint investorVotes = database.uintStorage(investorVotesID);
     uint totalVotes = database.uintStorage(voteTotalID);
-    uint numTokensLocked = database.uintStorage(keccak256(abi.encodePacked("tokensLocked", _assetID, msg.sender)));
+    address tokenAddress = database.addressStorage(keccak256(abi.encodePacked("tokenAddress", _proposalID)));
+    uint numTokensLocked = database.uintStorage(keccak256(abi.encodePacked("tokensLocked", tokenAddress, msg.sender)));
     require(investorVotes >= _amountToUnlock, "Amount to unlock greater than committed voted");   // 1 vote = 1 token
     database.setUint(voteTotalID, totalVotes.sub(_amountToUnlock));
     database.setUint(investorVotesID, investorVotes.sub(_amountToUnlock));
-    database.setUint(keccak256(abi.encodePacked("tokensLocked", _assetID, msg.sender)), numTokensLocked.sub(_amountToUnlock));
+    database.setUint(keccak256(abi.encodePacked("tokensLocked", tokenAddress, msg.sender)), numTokensLocked.sub(_amountToUnlock));
     return true;
   }
 
@@ -76,13 +92,12 @@ contract AssetGovernance {
   //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
   // @notice  Checks that 2/3 or more of token holders agreed on function call
-  function isConsensusReached(address _executingContract, bytes32 _assetID, bytes4 _methodID, bytes32 _parameterHash)
+  function isConsensusReached(bytes32 _proposalID)
   public
   view
   returns (bool) {
-    TokenView assetToken = TokenView(database.addressStorage(keccak256(abi.encodePacked("tokenAddress", _assetID))));
-    bytes32 executionID = keccak256(abi.encodePacked(_executingContract, _assetID, _methodID, _parameterHash));
-    bytes32 numVotesID = keccak256(abi.encodePacked("voteTotal", executionID));
+    TokenView assetToken = TokenView(database.addressStorage(keccak256(abi.encodePacked("tokenAddress", _proposalID))));
+    bytes32 numVotesID = keccak256(abi.encodePacked("voteTotal", _proposalID));
     uint256 numTokens = assetToken.totalSupply();
     return database.uintStorage(numVotesID).mul(scalingFactor).mul(100).div(numTokens).div(scalingFactor) >= consensus;
   }
@@ -95,6 +110,29 @@ contract AssetGovernance {
     selfdestruct(msg.sender);
   }
 
+  //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+  //                                 Voting Interface Functions
+  //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+  function result(bytes32 _proposalID)
+  external
+  view
+  onlyExtant(_proposalID)
+  returns (bool passed) {
+    bytes32 numVotesID = keccak256(abi.encodePacked("voteTotal", _proposalID));
+    uint256 numTokens = TokenView(database.addressStorage(keccak256(abi.encodePacked("tokenAddress", _proposalID)))).totalSupply();
+    events.consensus('Current consensus', _proposalID, numVotesID, database.uintStorage(numVotesID), numTokens, database.uintStorage(numVotesID).mul(100).div(numTokens));
+    //emit LogConsensus(numVotesID, database.uintStorage(numVotesID), numTokens, keccak256(abi.encodePacked(address(this), _assetID, _methodID, _parameterHash)), database.uintStorage(numVotesID).mul(100).div(numTokens));
+    return(database.uintStorage(numVotesID).mul(100).div(numTokens) >= consensus);
+  }
+
+  function proposalExtant(bytes32 _proposalID)
+  public
+  view
+  returns (bool extant) {
+    return (database.addressStorage(keccak256(abi.encodePacked("tokenAddress", _proposalID))) != address(0));
+  }
+
 
   //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
   //                                            Internal Functions
@@ -102,13 +140,13 @@ contract AssetGovernance {
 
   // @notice lock asset tokens to be able to vote
   // @dev keeps track of how many assetTokens this investor has locked (for GovernedToken checks)
-  function lockTokens(bytes32 _assetID, address _investor, uint _amount)
+  function lockTokens(bytes32 _proposalID, address _investor, uint _amount)
   internal
   returns (bool) {
-    TokenView assetToken = TokenView(database.addressStorage(keccak256(abi.encodePacked("tokenAddress", _assetID))));
-    uint numTokensLocked = database.uintStorage(keccak256(abi.encodePacked("tokensLocked", _assetID, _investor)));
+    TokenView assetToken = TokenView(database.addressStorage(keccak256(abi.encodePacked("tokenAddress", _proposalID))));
+    uint numTokensLocked = database.uintStorage(keccak256(abi.encodePacked("tokensLocked", address(assetToken), _investor)));
     require(_amount <= assetToken.balanceOf(_investor).sub(numTokensLocked), "Amount to lock greater than available");
-    database.setUint(keccak256(abi.encodePacked("tokensLocked", _assetID, _investor)), numTokensLocked.add(_amount));
+    database.setUint(keccak256(abi.encodePacked("tokensLocked", address(assetToken), _investor)), numTokensLocked.add(_amount));
     return true;
   }
 
@@ -119,14 +157,35 @@ contract AssetGovernance {
 
 
   // @notice reverts if the asset does not have a token address set in the database
-  modifier validAsset(bytes32 _assetID) {
-    require(database.addressStorage(keccak256(abi.encodePacked("tokenAddress", _assetID))) != address(0), "Invalid asset");
+  modifier validProposal(bytes32 _proposalID) {
+    require(database.addressStorage(keccak256(abi.encodePacked("tokenAddress", _proposalID))) != address(0), "Invalid asset");
     _;
   }
 
   // @notice Sender must be a registered owner
   modifier onlyOwner {
     require(database.boolStorage(keccak256(abi.encodePacked("owner", msg.sender))), "Not owner");
+    _;
+  }
+
+  modifier onlyApprovedContract() {
+      require(database.boolStorage(keccak256(abi.encodePacked("contract", msg.sender))));
+      _;
+  }
+
+  modifier onlyNew(bytes32 _proposalID) {
+    require(
+      !proposalExtant(_proposalID),
+      "Proposal exists"
+    );
+    _;
+  }
+
+  modifier onlyExtant(bytes32 _proposalID) {
+    require(
+      proposalExtant(_proposalID),
+      "Proposal not found"
+    );
     _;
   }
 

--- a/contracts/ownership/TokenGovernance.sol
+++ b/contracts/ownership/TokenGovernance.sol
@@ -31,7 +31,7 @@ contract TokenGovernance {
   // @notice quorum level dictates the number of votes required for that function to be executed
   constructor(address _database, address _events, uint256 _baseQuorum)
   public  {
-    governanceToken = ERC20(database.addressStorage(keccak256(abi.encodePacked("platformToken"))));
+    governanceToken = ERC20(database.addressStorage(keccak256(abi.encodePacked("tokenAddress", keccak256(abi.encodePacked("platformAssetID"))))));
     database = Database(_database);
     events = Events(_events);
     governanceToken = ERC20(governanceToken);

--- a/contracts/roles/AssetManagerEscrow.sol
+++ b/contracts/roles/AssetManagerEscrow.sol
@@ -2,6 +2,7 @@
 
   import "../math/SafeMath.sol";
   import "../interfaces/DBInterface.sol";
+  import "../interfaces/VotingInterface.sol";
   import "../database/Events.sol";
   import "../interfaces/DivToken.sol";
   import "../interfaces/BurnableERC20.sol";
@@ -16,15 +17,17 @@
 
     DBInterface public database;
     Events public events;
+    VotingInterface public votingProcess;
 
-    uint public consensus = 66;
+    //uint public consensus = 66;
 
     // @notice constructor: initializes database
     // @param: the address for the database contract used by this platform
-    constructor(address _database, address _events)
+    constructor(address _database, address _events, address _voting)
     public {
       database = DBInterface(_database);
       events = Events(_events);
+      votingProcess = VotingInterface(_voting);
     }
 
     // @dev assetID can be computed beforehand with sha3(msg.sender, _amountToRaise, _operatorID, _assetURI))
@@ -46,7 +49,7 @@
     returns (bool) {
       require(database.addressStorage(keccak256(abi.encodePacked("assetManager", _assetID))) == msg.sender);
       require(database.uintStorage(keccak256(abi.encodePacked("fundingDeadline", _assetID))) < now);
-      BurnableERC20 burnToken = BurnableERC20(database.addressStorage(keccak256(abi.encodePacked("platformToken"))));
+      BurnableERC20 burnToken = BurnableERC20(database.addressStorage(keccak256(abi.encodePacked("tokenAddress", keccak256(abi.encodePacked("platformAssetID"))))));
       bytes32 assetManagerEscrowID = keccak256(abi.encodePacked(_assetID, msg.sender));
       uint escrowRedeemed = database.uintStorage(keccak256(abi.encodePacked("escrowRedeemed", assetManagerEscrowID)));
       uint unlockAmount = database.uintStorage(keccak256(abi.encodePacked("assetManagerEscrow", assetManagerEscrowID))).sub(escrowRedeemed);
@@ -81,12 +84,19 @@
       require(currentAssetManager != msg.sender && currentAssetManager == _oldAssetManager);
       bytes32 oldAssetManagerEscrowID = keccak256(abi.encodePacked(_assetID, _oldAssetManager));
       uint oldEscrowRemaining = database.uintStorage(keccak256(abi.encodePacked("assetManagerEscrow", oldAssetManagerEscrowID))).sub(database.uintStorage(keccak256(abi.encodePacked("escrowRedeemed", oldAssetManagerEscrowID))));
-      BurnableERC20 token = BurnableERC20(database.addressStorage(keccak256(abi.encodePacked("platformToken"))));
+      BurnableERC20 token = BurnableERC20(database.addressStorage(keccak256(abi.encodePacked("tokenAddress", keccak256(abi.encodePacked("platformAssetID"))))));
       require(removeAssetManager(_assetID, oldAssetManagerEscrowID));
       if (_burn) { require(token.burn(oldEscrowRemaining)); }
       else { require(token.transfer(_oldAssetManager, oldEscrowRemaining));  }
       require(lockEscrowInternal(msg.sender, _assetID, _amount));
       return true;
+    }
+
+    function changeVotingProcess(address _newVotingContract)
+    external
+    hasConsensus(keccak256(abi.encodePacked("platformAssetID")), msg.sig, keccak256(abi.encodePacked(_newVotingContract)))
+    returns (bool) {
+      votingProcess = VotingInterface(_newVotingContract);
     }
 
     // @notice platform owners can destroy contract here
@@ -117,7 +127,7 @@
     returns (bool) {
       require(database.addressStorage(keccak256(abi.encodePacked("assetManager", _assetID))) == address(0));
       bytes32 assetManagerEscrowID = keccak256(abi.encodePacked(_assetID, _assetManager));
-      address tokenAddress = database.addressStorage(keccak256(abi.encodePacked("platformToken")));
+      address tokenAddress = database.addressStorage(keccak256(abi.encodePacked("tokenAddress", keccak256(abi.encodePacked("platformAssetID")))));
       require(BurnableERC20(tokenAddress).transferFrom(_assetManager, address(this), _amount));
       database.setUint(keccak256(abi.encodePacked("assetManagerEscrow", assetManagerEscrowID)), _amount);
       database.setAddress(keccak256(abi.encodePacked("assetManager", _assetID)), _assetManager);
@@ -134,12 +144,9 @@
 
     // @notice add this modifer to functions that you want multi-sig requirements for
     // @dev function can only be called after at least n >= quorumLevel owners have agreed to call it
-    modifier hasConsensus(bytes32 _assetID, bytes4 _methodID, bytes32 _parameterHash) {
-      bytes32 numVotesID = keccak256(abi.encodePacked("voteTotal", keccak256(abi.encodePacked(address(this), _assetID, _methodID, _parameterHash))));
-      uint256 numTokens = DivToken(database.addressStorage(keccak256(abi.encodePacked("tokenAddress", _assetID)))).totalSupply();
-      events.consensus('Current consensus', keccak256(abi.encodePacked(address(this), _assetID, _methodID, _parameterHash)), numVotesID, database.uintStorage(numVotesID), numTokens, database.uintStorage(numVotesID).mul(100).div(numTokens));
-      //emit LogConsensus(numVotesID, database.uintStorage(numVotesID), numTokens, keccak256(abi.encodePacked(address(this), _assetID, _methodID, _parameterHash)), database.uintStorage(numVotesID).mul(100).div(numTokens));
-      require(database.uintStorage(numVotesID).mul(100).div(numTokens) >= consensus, 'Consensus not reached');
+    modifier hasConsensus(bytes32 _assetID, bytes4 _methodID, bytes32 _parameterHash){
+      bytes32 proposalID = keccak256(abi.encodePacked(address(this), _assetID, _methodID, _parameterHash));
+      require(votingProcess.result(proposalID));
       _;
     }
 

--- a/contracts/test/TimedVoteStub.sol
+++ b/contracts/test/TimedVoteStub.sol
@@ -14,13 +14,12 @@ contract TimedVoteStub is TimedVote {
   /** Relay all arguments */
   constructor(
     address _database,
-    address _tokenAddress,
     uint256 _voteDuration,
     uint8 _quorum,
     uint8 _threshold
   )
   public
-  TimedVote(_database, _tokenAddress, _voteDuration, _quorum, _threshold) {
+  TimedVote(_database, _voteDuration, _quorum, _threshold) {
     timestamp = now;
   }
 
@@ -44,35 +43,35 @@ contract TimedVoteStub is TimedVote {
   }
 
   /** Get commitment age */
-  function _commitmentAge(address _account)
+  function _commitmentAge(address _account, bytes32 _assetID)
   external
   view
   returns (uint256 age) {
-    return commitmentAge(_account);
+    return commitmentAge(_account, _assetID);
   }
 
   /** Check commitment locked */
-  function _commitmentLocked(address _account)
+  function _commitmentLocked(address _account, bytes32 _assetID)
   external
   view
   returns (bool locked) {
-    return commitmentLocked(_account);
+    return commitmentLocked(_account, _assetID);
   }
 
   /** Check commitment tier 2 */
-  function _commitmentTier2(address _account)
+  function _commitmentTier2(address _account, bytes32 _assetID)
   external
   view
   returns (bool tier2) {
-    return commitmentTier2(_account);
+    return commitmentTier2(_account, _assetID);
   }
 
   /** Check commitment tier 3 */
-  function _commitmentTier3(address _account)
+  function _commitmentTier3(address _account, bytes32 _assetID)
   external
   view
   returns (bool tier3) {
-    return commitmentTier3(_account);
+    return commitmentTier3(_account, _assetID);
   }
 
   /** Check account has voted */
@@ -106,10 +105,10 @@ contract TimedVoteStub is TimedVote {
   onlyClosed(_proposalID) {}
 
   /** Require sender committed */
-  function _onlyCommitted()
+  function _onlyCommitted(bytes32 _assetID)
   external
   view
-  onlyCommitted(msg.sender) {}
+  onlyCommitted(msg.sender, _assetID) {}
 
   /** Require proposal extant */
   function _onlyExtant(bytes32 _proposalID)
@@ -147,16 +146,16 @@ contract TimedVoteStub is TimedVote {
   onlyPositive(_number) {}
 
   /** Require sender uncommitted */
-  function _onlyUncommitted()
+  function _onlyUncommitted(bytes32 _assetID)
   external
   view
-  onlyUncommitted(msg.sender) {}
+  onlyUncommitted(msg.sender, _assetID) {}
 
   /** Require commitment unlocked */
-  function _onlyUnlocked()
+  function _onlyUnlocked(bytes32 _assetID)
   external
   view
-  onlyUnlocked(msg.sender) {}
+  onlyUnlocked(msg.sender, _assetID) {}
 
   /** Require address valid */
   function _onlyValidAddress(address _address)
@@ -165,10 +164,10 @@ contract TimedVoteStub is TimedVote {
   onlyValid(_address) {}
 
   /** Require voting body */
-  function _onlyVotingBody()
+  function _onlyVotingBody(bytes32 _assetID)
   external
   view
-  onlyVotingBody {}
+  onlyVotingBody(_assetID) {}
 
   /** Percentage */
   function _percentage(uint256 _portion, uint256 _total)
@@ -233,13 +232,13 @@ contract TimedVoteStub is TimedVote {
    * Add proposal
    * @param _proposalID - Identifier of new proposal.
    */
-  function _addProposal(bytes32 _proposalID)
+  function _addProposal(bytes32 _proposalID, bytes32 _assetID)
   external {
     database.setUint(keccak256(abi.encodePacked(_proposalID, "Proposal", "start")), time());
-    database.setUint(keccak256(abi.encodePacked(_proposalID, "Proposal", "body")), body);
     database.setUint(keccak256(abi.encodePacked(_proposalID, "Proposal", "voted")), 0);
     database.setUint(keccak256(abi.encodePacked(_proposalID, "Proposal", "approval")), 0);
     database.setUint(keccak256(abi.encodePacked(_proposalID, "Proposal", "dissent")), 0);
+    database.setBytes32(keccak256(abi.encodePacked(_proposalID, "Proposal", "assetID")), _assetID);
   }
 
   /**
@@ -258,9 +257,9 @@ contract TimedVoteStub is TimedVote {
    * Set voting body amount
    * @param _amount - Voting body amount.
    */
-  function _setBody(uint256 _amount)
+  function _setBody(bytes32 _assetID, uint256 _amount)
   external {
-    body = _amount;
+    body[_assetID] = _amount;
   }
 
   /**
@@ -268,11 +267,11 @@ contract TimedVoteStub is TimedVote {
    * @param _account - Account to set commitment of.
    * @param _amount - MYB commitment amount.
    */
-  function _setCommitment(address _account, uint256 _amount)
+  function _setCommitment(address _account, bytes32 _assetID, uint256 _amount)
   external {
-    body = body.add(_amount);
-    database.setUint(keccak256(abi.encodePacked(_account, "Commitment", "value")), _amount);
-    database.setUint(keccak256(abi.encodePacked(_account, "Commitment", "time")), time());
+    body[_assetID] = body[_assetID].add(_amount);
+    database.setUint(keccak256(abi.encodePacked(_account, _assetID, "Commitment", "value")), _amount);
+    database.setUint(keccak256(abi.encodePacked(_account, _assetID, "Commitment", "time")), time());
   }
 
   /**

--- a/contracts/tokens/erc20/GovernedToken.sol
+++ b/contracts/tokens/erc20/GovernedToken.sol
@@ -51,8 +51,7 @@ contract GovernedToken is DividendToken, BurnableToken {
   public
   view
   returns (uint) {
-    bytes32 assetID = database.bytes32Storage(keccak256(abi.encodePacked("assetTokenID", address(this))));
-    uint amountLocked = database.uintStorage(keccak256(abi.encodePacked("tokensLocked", assetID, _investor)));
+    uint amountLocked = database.uintStorage(keccak256(abi.encodePacked("tokensLocked", address(this), _investor)));
     uint balance = balances[_investor];
     uint available = balance.sub(amountLocked);
     return available;

--- a/migrations/2_deploy_protocol.js
+++ b/migrations/2_deploy_protocol.js
@@ -11,6 +11,7 @@ var ERC20Burner = artifacts.require("./access/ERC20Burner.sol");
 var AccessHierarchy = artifacts.require("./access/AccessHierarchy.sol");
 var PlatformFunds = artifacts.require("./ecosystem/PlatformFunds.sol");
 var Operators = artifacts.require("./roles/Operators.sol");
+var AssetGovernance = artifacts.require("./ownership/AssetGovernance.sol");
 var AssetManagerEscrow = artifacts.require("./roles/AssetManagerEscrow.sol");
 var AssetManagerFunds = artifacts.require("./roles/AssetManagerFunds.sol");
 var AssetGenerator = artifacts.require("./ecosystem/AssetGenerator.sol");
@@ -27,7 +28,8 @@ var tokenPerAccount = 100*decimals;
 
 var safemath, MyB, db, events, cm, api, owned, pausible, burner, access,
     platform, operators, escrow, managerFunds, assetGenerator, crowdsaleETH,
-    crowdsaleGeneratorETH, crowdsaleERC20, crowdsaleGeneratorERC20, dax;
+    crowdsaleGeneratorETH, crowdsaleERC20, crowdsaleGeneratorERC20, dax,
+    governance;
 
 module.exports = function(deployer, network, accounts) {
   deployer.then(function(){
@@ -40,6 +42,7 @@ module.exports = function(deployer, network, accounts) {
     deployer.link(SafeMath,
                   API,
                   MyBitToken,
+                  AssetGovernance,
                   AssetManagerEscrow,
                   Operators,
                   CrowdsaleETH,
@@ -148,7 +151,15 @@ module.exports = function(deployer, network, accounts) {
     console.log('AccessHierarchy.sol: ' + access.address);
     cm.addContract('AccessHierarchy', access.address);
 
-    return AssetManagerEscrow.new(db.address, events.address);
+    return AssetGovernance.new(db.address, events.address);
+
+  }).then(function(instance) {
+
+    governance = instance;
+    console.log('AssetGovernance.sol: ' + governance.address);
+    cm.addContract('AssetGovernance', governance.address);
+
+    return AssetManagerEscrow.new(db.address, events.address, governance.address);
 
   }).then(function(instance) {
 
@@ -240,6 +251,7 @@ module.exports = function(deployer, network, accounts) {
       "AccessHierarchy" : access.address,
       "PlatformFunds" : platform.address,
       "Operators" : operators.address,
+      "AssetGovernance" : governance.address,
       "AssetManagerEscrow" : escrow.address,
       "AssetManagerFunds" : managerFunds.address,
       "AssetGenerator" : assetGenerator.address,

--- a/test/AssetManagerEscrow.js
+++ b/test/AssetManagerEscrow.js
@@ -1,6 +1,7 @@
 var bn = require('bignumber.js');
 
 const AssetManagerEscrow = artifacts.require("./roles/AssetManagerEscrow.sol");
+const AssetGovernance = artifacts.require("./ownership/AssetGovernance");
 const Database = artifacts.require("./database/Database.sol");
 const Events = artifacts.require("./database/Events.sol");
 const ContractManager = artifacts.require("./database/ContractManager.sol");
@@ -41,6 +42,7 @@ contract('AssetManager Escrow', async() => {
   let api;
   let hash;
   let escrow;
+  let governance;
   let platform;
   let operators;
 
@@ -76,6 +78,11 @@ contract('AssetManager Escrow', async() => {
     burnToken = await MyBitToken.new('MyB', 10000*ETH);
   });
 
+  it("Deploy asset goverance", async() => {
+    governance = await AssetGovernance.new(db.address, events.address);
+    await cm.addContract('AssetGovernance', governance.address);
+  })
+
   it("Transfer token to assetManager", async() => {
     await burnToken.transfer(assetManager, 100*ETH);
     assetManagerBalance = await burnToken.balanceOf(assetManager);
@@ -90,7 +97,7 @@ contract('AssetManager Escrow', async() => {
   });
 
   it('Deploy assetManager escrow', async() => {
-    escrow = await AssetManagerEscrow.new(db.address, events.address);
+    escrow = await AssetManagerEscrow.new(db.address, events.address, governance.address);
     await cm.addContract('AssetManagerEscrow', escrow.address);
   });
 

--- a/test/TimedVote.js
+++ b/test/TimedVote.js
@@ -5,6 +5,8 @@ const TimedVote = artifacts.require('TimedVoteStub');
 const Database = artifacts.require('Database');
 const Events = artifacts.require('Events');
 const ContractManager = artifacts.require('ContractManager');
+const API = artifacts.require('API');
+const PlatformFunds = artifacts.require('PlatformFunds');
 
 const owner = web3.eth.accounts[0];
 const user1 = web3.eth.accounts[1];
@@ -28,7 +30,7 @@ const validAddress = '0xbaCc40C0Df5E6eC2B0A4e9d1A0F748473F7f8b1a';
 const proposalID = '0x0011223344556677889900112233445566778899001122334455667788990011';
 
 
-let token, timedVote, db, ev, cm;
+let token, timedVote, db, ev, cm, api, platformFunds, platformAssetID;
 
 
 async function throws (executor) {
@@ -41,25 +43,32 @@ async function throws (executor) {
 async function rejects (promise) {
   try {
     await promise;
+    console.log("Promise succeeds");
     assert.fail('Incorrect success');
-  } catch (e) {}
+  } catch (e) {
+    console.log("Promise fails");
+  }
 }
 
 
 contract('TimedVote', () => {
-
   // ----
   // Hook
   // ----
   beforeEach(async() => {
-    token = await Token.new("MyBit", tokenSupply);
     db = await Database.new([owner], true);
     ev = await Events.new(db.address);
     cm = await ContractManager.new(db.address, ev.address);
     await db.enableContractManagement(cm.address);
+    api = await API.new(db.address);
+    await cm.addContract("API", api.address);
+    platformFunds = await PlatformFunds.new(db.address, ev.address);
+    await cm.addContract("PlatformFunds", platformFunds.address);
+    platformAssetID = await api.getPlatformAssetID();
+    token = await Token.new("MyBit", tokenSupply);
+    await platformFunds.setPlatformToken(token.address);
     timedVote = await TimedVote.new(
       db.address,
-      token.address,
       voteDuration,
       quorum,
       threshold
@@ -67,16 +76,17 @@ contract('TimedVote', () => {
     await cm.addContract("TimedVote", timedVote.address);
   });
 
+
   // ---------
   // Construct
   // ---------
 
   describe('Construct', () => {
     it('Succeed', async() => {
-      await TimedVote.new(db.address, token.address, voteDuration, quorum, threshold);
+      await TimedVote.new(db.address, voteDuration, quorum, threshold);
     });
 
-    it('Fail with null token address', async() => {
+    it('Fail with null database address', async() => {
       await rejects(TimedVote.new(
         NULL_ADDRESS,
         voteDuration,
@@ -86,7 +96,7 @@ contract('TimedVote', () => {
     });
 
     it('Fail with 0 vote duration', async() => {
-      await rejects(TimedVote.new(db.address, token.address, 0, quorum, threshold));
+      await rejects(TimedVote.new(db.address, 0, quorum, threshold));
     });
   });
 
@@ -115,71 +125,71 @@ contract('TimedVote', () => {
   describe('View Condition', () => {
     describe('#accountCommitted', () => {
       it('Uncommitted', async() => {
-        const committed = await timedVote.accountCommitted(user1);
+        const committed = await timedVote.accountCommitted(user1, platformAssetID);
         assert.isFalse(committed);
       });
 
       it('Committed', async() => {
-        await timedVote._setCommitment(user1, 5);
-        const committed = await timedVote.accountCommitted(user1);
+        await timedVote._setCommitment(user1, platformAssetID, 5);
+        const committed = await timedVote.accountCommitted(user1, platformAssetID);
         assert.isTrue(committed);
       });
     });
 
     describe('~commitmentLocked', () => {
       it('Locked', async() => {
-        await timedVote._setCommitment(user1, 5);
-        const locked = await timedVote._commitmentLocked(user1);
+        await timedVote._setCommitment(user1, platformAssetID, 5);
+        const locked = await timedVote._commitmentLocked(user1, platformAssetID);
         assert.isTrue(locked);
       });
 
       it('Unlocked', async() => {
-        await timedVote._setCommitment(user1, 5);
+        await timedVote._setCommitment(user1, platformAssetID, 5);
         await timedVote._timeTravelDays(unlockDays);
-        const locked = await timedVote._commitmentLocked(user1);
+        const locked = await timedVote._commitmentLocked(user1, platformAssetID);
         assert.isFalse(locked);
       });
     });
 
     describe('~commitmentTier2', () => {
       it('Prior tier', async() => {
-        await timedVote._setCommitment(user1, 5);
-        const tier2 = await timedVote._commitmentTier2(user1);
+        await timedVote._setCommitment(user1, platformAssetID, 5);
+        const tier2 = await timedVote._commitmentTier2(user1, platformAssetID);
         assert.isFalse(tier2);
       });
 
       it('Tier 2', async() => {
-        await timedVote._setCommitment(user1, 5);
+        await timedVote._setCommitment(user1, platformAssetID, 5);
         await timedVote._timeTravelDays(tier2Days);
-        const tier2 = await timedVote._commitmentTier2(user1);
+        const tier2 = await timedVote._commitmentTier2(user1, platformAssetID);
         assert.isTrue(tier2);
       });
     });
 
     describe('~commitmentTier3', () => {
       it('Prior tier', async() => {
-        await timedVote._setCommitment(user1, 5);
-        const tier3 = await timedVote._commitmentTier3(user1);
+        await timedVote._setCommitment(user1, platformAssetID, 5);
+        const tier3 = await timedVote._commitmentTier3(user1, platformAssetID);
         assert.isFalse(tier3);
       });
 
       it('Tier 3', async() => {
-        await timedVote._setCommitment(user1, 5);
+        await timedVote._setCommitment(user1, platformAssetID, 5);
         await timedVote._timeTravelDays(tier3Days);
-        const tier3 = await timedVote._commitmentTier3(user1);
+        const tier3 = await timedVote._commitmentTier3(user1, platformAssetID);
         assert.isTrue(tier3);
       });
     });
 
     describe('~hasVoted', () => {
       it('No vote', async() => {
-        await timedVote._addProposal(proposalID);
+        await timedVote._addProposal(proposalID, platformAssetID);
         const voted = await timedVote._hasVoted(user1, proposalID);
         assert.isFalse(voted);
       });
 
       it('Vote', async() => {
-        await timedVote._addProposal(proposalID);
+        await timedVote._addProposal(proposalID, platformAssetID);
         await timedVote._setVoter(proposalID, user1);
         const voted = await timedVote._hasVoted(user1, proposalID);
         assert.isTrue(voted);
@@ -190,8 +200,8 @@ contract('TimedVote', () => {
       it('Over', async() => {
         const body = tokenSupply / 2;
         const amount = (quorum + 10) / 100 * body;
-        await timedVote._setBody(body);
-        await timedVote._addProposal(proposalID);
+        await timedVote._setBody(platformAssetID, body);
+        await timedVote._addProposal(proposalID, platformAssetID);
         await timedVote._setVoted(proposalID, amount);
         const meets = await timedVote._meetsQuorum(proposalID);
         assert.isTrue(meets);
@@ -200,8 +210,8 @@ contract('TimedVote', () => {
       it('Under', async() => {
         const body = tokenSupply / 2;
         const amount = (quorum - 10) / 100 * body;
-        await timedVote._setBody(body);
-        await timedVote._addProposal(proposalID);
+        await timedVote._setBody(platformAssetID, body);
+        await timedVote._addProposal(proposalID, platformAssetID);
         await timedVote._setVoted(proposalID, amount);
         const meets = await timedVote._meetsQuorum(proposalID);
         assert.isFalse(meets);
@@ -210,8 +220,8 @@ contract('TimedVote', () => {
       it('At', async() => {
         const body = tokenSupply / 2;
         const amount = quorum / 100 * body;
-        await timedVote._setBody(body);
-        await timedVote._addProposal(proposalID);
+        await timedVote._setBody(platformAssetID, body);
+        await timedVote._addProposal(proposalID, platformAssetID);
         await timedVote._setVoted(proposalID, amount);
         const meets = await timedVote._meetsQuorum(proposalID);
         assert.isTrue(meets);
@@ -222,7 +232,7 @@ contract('TimedVote', () => {
       it('Over', async() => {
         const approval = 900;
         const dissent = 100;
-        await timedVote._addProposal(proposalID);
+        await timedVote._addProposal(proposalID, platformAssetID);
         await timedVote._setApproval(proposalID, approval);
         await timedVote._setDissent(proposalID, dissent);
         const meets = await timedVote._meetsThreshold(proposalID);
@@ -232,7 +242,7 @@ contract('TimedVote', () => {
       it('Under', async() => {
         const approval = 200;
         const dissent = 800;
-        await timedVote._addProposal(proposalID);
+        await timedVote._addProposal(proposalID, platformAssetID);
         await timedVote._setApproval(proposalID, approval);
         await timedVote._setDissent(proposalID, dissent);
         const meets = await timedVote._meetsThreshold(proposalID);
@@ -242,7 +252,7 @@ contract('TimedVote', () => {
       it('At', async() => {
         const approval = 510;
         const dissent = 490;
-        await timedVote._addProposal(proposalID);
+        await timedVote._addProposal(proposalID, platformAssetID);
         await timedVote._setApproval(proposalID, approval);
         await timedVote._setDissent(proposalID, dissent);
         const meets = await timedVote._meetsThreshold(proposalID);
@@ -252,7 +262,7 @@ contract('TimedVote', () => {
 
     describe('#proposalExtant', () => {
       it('Extant', async() => {
-        await timedVote._addProposal(proposalID);
+        await timedVote._addProposal(proposalID, platformAssetID);
         const extant = await timedVote.proposalExtant(proposalID);
         assert.isTrue(extant);
       });
@@ -265,13 +275,13 @@ contract('TimedVote', () => {
 
     describe('~proposalOpen', () => {
       it('Open', async() => {
-        await timedVote._addProposal(proposalID);
+        await timedVote._addProposal(proposalID, platformAssetID);
         const open = await timedVote._proposalOpen(proposalID);
         assert.isTrue(open);
       });
 
       it('Closed', async() => {
-        await timedVote._addProposal(proposalID);
+        await timedVote._addProposal(proposalID, platformAssetID);
         await timedVote._timeTravelDays(closeDays);
         const open = await timedVote._proposalOpen(proposalID);
         assert.isFalse(open);
@@ -351,14 +361,14 @@ contract('TimedVote', () => {
   describe('View Value', () => {
     describe('~approvalPercentage', () => {
       it('0%', async() => {
-        await timedVote._addProposal(proposalID);
+        await timedVote._addProposal(proposalID, platformAssetID);
         await timedVote._setDissent(proposalID, 1000);
         const percent = await timedVote._approvalPercentage(proposalID);
         assert.isTrue(BigNumber(percent).isEqualTo(0));
       });
 
       it('50%', async() => {
-        await timedVote._addProposal(proposalID);
+        await timedVote._addProposal(proposalID, platformAssetID);
         await timedVote._setApproval(proposalID, 500);
         await timedVote._setDissent(proposalID, 500);
         const percent = await timedVote._approvalPercentage(proposalID);
@@ -366,7 +376,7 @@ contract('TimedVote', () => {
       });
 
       it('100%', async() => {
-        await timedVote._addProposal(proposalID);
+        await timedVote._addProposal(proposalID, platformAssetID);
         await timedVote._setApproval(proposalID, 1000);
         const percent = await timedVote._approvalPercentage(proposalID);
         assert.isTrue(BigNumber(percent).isEqualTo(100));
@@ -375,63 +385,63 @@ contract('TimedVote', () => {
 
     describe('~commitmentAge', () => {
       it('Birth', async() => {
-        await timedVote._setCommitment(user1, 5);
-        const age = await timedVote._commitmentAge(user1);
+        await timedVote._setCommitment(user1, platformAssetID, 5);
+        const age = await timedVote._commitmentAge(user1, platformAssetID);
         assert.isTrue(BigNumber(age).isEqualTo(0));
       });
 
       it('Terrible 2s', async() => {
-        await timedVote._setCommitment(user1, 5);
+        await timedVote._setCommitment(user1, platformAssetID, 5);
         await timedVote._timeTravelSeconds(222);
-        const age = await timedVote._commitmentAge(user1);
+        const age = await timedVote._commitmentAge(user1, platformAssetID);
         assert.isTrue(BigNumber(age).isEqualTo(222));
       });
     });
 
     describe('#commitmentOf', () => {
       it('No commitment', async() => {
-        const result = await timedVote.commitmentOf(user1);
+        const result = await timedVote.commitmentOf(user1, platformAssetID);
         assert.isTrue(BigNumber(result).isEqualTo(0));
       });
 
       it('Commitment', async() => {
-        await timedVote._setCommitment(user1, 100);
-        const result = await timedVote.commitmentOf(user1);
+        await timedVote._setCommitment(user1, platformAssetID, 100);
+        const result = await timedVote.commitmentOf(user1, platformAssetID);
         assert.isTrue(BigNumber(result).isEqualTo(100));
       });
     });
 
     describe('#multiplierOf', () => {
       it('Tier 1', async() => {
-        await timedVote._setCommitment(user1, 5);
-        const multiplier = await timedVote.multiplierOf(user1);
+        await timedVote._setCommitment(user1, platformAssetID, 5);
+        const multiplier = await timedVote.multiplierOf(user1, platformAssetID);
         assert.isTrue(BigNumber(multiplier).isEqualTo(tier1Multiplier));
       });
 
       it('Tier 2', async() => {
-        await timedVote._setCommitment(user1, 5);
+        await timedVote._setCommitment(user1, platformAssetID, 5);
         await timedVote._timeTravelDays(tier2Days);
-        const multiplier = await timedVote.multiplierOf(user1);
+        const multiplier = await timedVote.multiplierOf(user1, platformAssetID);
         assert.isTrue(BigNumber(multiplier).isEqualTo(tier2Multiplier));
       });
 
       it('Tier 3', async() => {
-        await timedVote._setCommitment(user1, 5);
+        await timedVote._setCommitment(user1, platformAssetID, 5);
         await timedVote._timeTravelDays(tier3Days);
-        const multiplier = await timedVote.multiplierOf(user1);
+        const multiplier = await timedVote.multiplierOf(user1, platformAssetID);
         assert.isTrue(BigNumber(multiplier).isEqualTo(tier3Multiplier));
       });
     });
 
     describe('~proposalAge', () => {
       it('Birth', async() => {
-        await timedVote._addProposal(proposalID);
+        await timedVote._addProposal(proposalID, platformAssetID);
         const age = await timedVote._proposalAge(proposalID);
         assert.isTrue(BigNumber(age).isEqualTo(0));
       });
 
       it('Terrible 2s', async() => {
-        await timedVote._addProposal(proposalID);
+        await timedVote._addProposal(proposalID, platformAssetID);
         await timedVote._timeTravelSeconds(222);
         const age = await timedVote._proposalAge(proposalID);
         assert.isTrue(BigNumber(age).isEqualTo(222));
@@ -448,27 +458,27 @@ contract('TimedVote', () => {
 
     describe('~totalVotes', () => {
       it('None', async() => {
-        await timedVote._addProposal(proposalID);
+        await timedVote._addProposal(proposalID, platformAssetID);
         const votes = await timedVote._totalVotes(proposalID);
         assert.isTrue(BigNumber(votes).isEqualTo(0));
       });
 
       it('Approval', async() => {
-        await timedVote._addProposal(proposalID);
+        await timedVote._addProposal(proposalID, platformAssetID);
         await timedVote._setApproval(proposalID, 50);
         const votes = await timedVote._totalVotes(proposalID);
         assert.isTrue(BigNumber(votes).isEqualTo(50));
       });
 
       it('Dissent', async() => {
-        await timedVote._addProposal(proposalID);
+        await timedVote._addProposal(proposalID, platformAssetID);
         await timedVote._setDissent(proposalID, 50);
         const votes = await timedVote._totalVotes(proposalID);
         assert.isTrue(BigNumber(votes).isEqualTo(50));
       });
 
       it('Mixed', async() => {
-        await timedVote._addProposal(proposalID);
+        await timedVote._addProposal(proposalID, platformAssetID);
         await timedVote._setApproval(proposalID, 50);
         await timedVote._setDissent(proposalID, 50);
         const votes = await timedVote._totalVotes(proposalID);
@@ -478,39 +488,39 @@ contract('TimedVote', () => {
 
     describe('~votingPercentage', () => {
       it('None', async() => {
-        await timedVote._setCommitment(user1, tokenSupply / 2);
+        await timedVote._setCommitment(user1, platformAssetID, tokenSupply / 2);
         await timedVote._timeTravelDays(unlockDays);
-        await timedVote._addProposal(proposalID);
+        await timedVote._addProposal(proposalID, platformAssetID);
         const percent = await timedVote._votingPercentage(proposalID);
         assert.isTrue(BigNumber(percent).isEqualTo(0));
       });
 
       it('Half approve', async() => {
-        await timedVote._setCommitment(user1, tokenSupply / 4);
-        await timedVote._setCommitment(user2, tokenSupply / 4);
+        await timedVote._setCommitment(user1, platformAssetID, tokenSupply / 4);
+        await timedVote._setCommitment(user2, platformAssetID, tokenSupply / 4);
         await timedVote._timeTravelDays(unlockDays);
-        await timedVote._addProposal(proposalID);
+        await timedVote._addProposal(proposalID, platformAssetID);
         await timedVote.approve(proposalID, {from: user1});
         const percent = await timedVote._votingPercentage(proposalID);
         assert.isTrue(BigNumber(percent).isEqualTo(50));
       });
 
       it('Half decline', async() => {
-        await timedVote._setCommitment(user1, tokenSupply / 4);
-        await timedVote._setCommitment(user2, tokenSupply / 4);
+        await timedVote._setCommitment(user1, platformAssetID, tokenSupply / 4);
+        await timedVote._setCommitment(user2, platformAssetID, tokenSupply / 4);
         await timedVote._timeTravelDays(unlockDays);
-        await timedVote._addProposal(proposalID);
+        await timedVote._addProposal(proposalID, platformAssetID);
         await timedVote.decline(proposalID, {from: user1});
         const percent = await timedVote._votingPercentage(proposalID);
         assert.isTrue(BigNumber(percent).isEqualTo(50));
       });
 
       it('Half mixed', async() => {
-        await timedVote._setCommitment(user1, tokenSupply / 8);
-        await timedVote._setCommitment(user2, tokenSupply / 8);
-        await timedVote._setCommitment(user3, tokenSupply / 4);
+        await timedVote._setCommitment(user1, platformAssetID, tokenSupply / 8);
+        await timedVote._setCommitment(user2, platformAssetID, tokenSupply / 8);
+        await timedVote._setCommitment(user3, platformAssetID, tokenSupply / 4);
         await timedVote._timeTravelDays(unlockDays);
-        await timedVote._addProposal(proposalID);
+        await timedVote._addProposal(proposalID, platformAssetID);
         await timedVote.approve(proposalID, {from: user1});
         await timedVote.decline(proposalID, {from: user2});
         const percent = await timedVote._votingPercentage(proposalID);
@@ -518,28 +528,28 @@ contract('TimedVote', () => {
       });
 
       it('Full approve', async() => {
-        await timedVote._setCommitment(user1, tokenSupply / 2);
+        await timedVote._setCommitment(user1, platformAssetID, tokenSupply / 2);
         await timedVote._timeTravelDays(unlockDays);
-        await timedVote._addProposal(proposalID);
+        await timedVote._addProposal(proposalID, platformAssetID);
         await timedVote.approve(proposalID, {from: user1});
         const percent = await timedVote._votingPercentage(proposalID);
         assert.isTrue(BigNumber(percent).isEqualTo(100));
       });
 
       it('Full decline', async() => {
-        await timedVote._setCommitment(user1, tokenSupply / 2);
+        await timedVote._setCommitment(user1, platformAssetID, tokenSupply / 2);
         await timedVote._timeTravelDays(unlockDays);
-        await timedVote._addProposal(proposalID);
+        await timedVote._addProposal(proposalID, platformAssetID);
         await timedVote.decline(proposalID, {from: user1});
         const percent = await timedVote._votingPercentage(proposalID);
         assert.isTrue(BigNumber(percent).isEqualTo(100));
       });
 
       it('Full mixed', async() => {
-        await timedVote._setCommitment(user1, tokenSupply / 4);
-        await timedVote._setCommitment(user2, tokenSupply / 4);
+        await timedVote._setCommitment(user1, platformAssetID, tokenSupply / 4);
+        await timedVote._setCommitment(user2, platformAssetID, tokenSupply / 4);
         await timedVote._timeTravelDays(unlockDays);
-        await timedVote._addProposal(proposalID);
+        await timedVote._addProposal(proposalID, platformAssetID);
         await timedVote.approve(proposalID, {from: user1});
         await timedVote.decline(proposalID, {from: user2});
         const percent = await timedVote._votingPercentage(proposalID);
@@ -555,31 +565,31 @@ contract('TimedVote', () => {
   describe('Modifier', () => {
     describe('~onlyClosed(proposal)', () => {
       it('Accept closed', async() => {
-        await timedVote._addProposal(proposalID);
+        await timedVote._addProposal(proposalID, platformAssetID);
         await timedVote._timeTravelDays(closeDays);
         await timedVote._onlyClosedProposal(proposalID);
       });
 
       it('Reject open', async() => {
-        await timedVote._addProposal(proposalID);
+        await timedVote._addProposal(proposalID, platformAssetID);
         await rejects(timedVote._onlyClosedProposal(proposalID));
       });
     });
 
     describe('~onlyCommitted', () => {
       it('Reject uncommitted', async() => {
-        await rejects(timedVote._onlyCommitted({from: user1}));
+        await rejects(timedVote._onlyCommitted(platformAssetID, {from: user1}));
       });
 
       it('Accept committed', async() => {
-        await timedVote._setCommitment(user1, 5);
-        await timedVote._onlyCommitted({from: user1});
+        await timedVote._setCommitment(user1, platformAssetID, 5);
+        await timedVote._onlyCommitted(platformAssetID, {from: user1});
       });
     });
 
     describe('~onlyExtant(proposal)', () => {
       it('Accept extant', async() => {
-        await timedVote._addProposal(proposalID);
+        await timedVote._addProposal(proposalID, platformAssetID);
         await timedVote._onlyExtant(proposalID);
       });
 
@@ -616,19 +626,19 @@ contract('TimedVote', () => {
       });
 
       it('Reject extant', async() => {
-        await timedVote._addProposal(proposalID);
+        await timedVote._addProposal(proposalID, platformAssetID);
         await rejects(timedVote._onlyNew(proposalID));
       });
     });
 
     describe('~onlyOneVote', () => {
       it('Accept first', async() => {
-        await timedVote._addProposal(proposalID);
+        await timedVote._addProposal(proposalID, platformAssetID);
         await timedVote._onlyOneVote(proposalID, user1);
       });
 
       it('Reject subsequent', async() => {
-        await timedVote._addProposal(proposalID);
+        await timedVote._addProposal(proposalID, platformAssetID);
         await timedVote._setVoter(proposalID, user1);
         await rejects(timedVote._onlyOneVote(proposalID, user1));
       });
@@ -636,12 +646,12 @@ contract('TimedVote', () => {
 
     describe('~onlyOpen(proposal)', () => {
       it('Accept open', async() => {
-        await timedVote._addProposal(proposalID);
+        await timedVote._addProposal(proposalID, platformAssetID);
         await timedVote._onlyOpenProposal(proposalID);
       });
 
       it('Reject closed', async() => {
-        await timedVote._addProposal(proposalID);
+        await timedVote._addProposal(proposalID, platformAssetID);
         await timedVote._timeTravelDays(closeDays);
         await rejects(timedVote._onlyOpenProposal(proposalID));
       });
@@ -663,25 +673,25 @@ contract('TimedVote', () => {
 
     describe('~onlyUncommitted', () => {
       it('Accept uncommitted', async() => {
-        await timedVote._onlyUncommitted({from: user1});
+        await timedVote._onlyUncommitted(platformAssetID, {from: user1});
       });
 
       it('Reject committed', async() => {
-        await timedVote._setCommitment(user1, 5);
-        await rejects(timedVote._onlyUncommitted({from: user1}));
+        await timedVote._setCommitment(user1, platformAssetID, 5);
+        await rejects(timedVote._onlyUncommitted(platformAssetID, {from: user1}));
       });
     });
 
     describe('~onlyUnlocked', () => {
       it('Accept unlocked', async() => {
-        await timedVote._setCommitment(user1, 5);
+        await timedVote._setCommitment(user1, platformAssetID, 5);
         await timedVote._timeTravelDays(unlockDays);
-        await timedVote._onlyUnlocked({from: user1});
+        await timedVote._onlyUnlocked(platformAssetID, {from: user1});
       });
 
       it('Reject locked', async() => {
-        await timedVote._setCommitment(user1, 5);
-        await rejects(timedVote._onlyUnlocked({from: user1}));
+        await timedVote._setCommitment(user1, platformAssetID, 5);
+        await rejects(timedVote._onlyUnlocked(platformAssetID, {from: user1}));
       });
     });
 
@@ -697,12 +707,12 @@ contract('TimedVote', () => {
 
     describe('~onlyVotingBody', () => {
       it('Reject without voting body', async() => {
-        await rejects(timedVote._onlyVotingBody());
+        await rejects(timedVote._onlyVotingBody(platformAssetID));
       });
 
       it('Accept with voting body', async() => {
-        await timedVote._setBody(1);
-        await timedVote._onlyVotingBody();
+        await timedVote._setBody(platformAssetID, 1);
+        await timedVote._onlyVotingBody(platformAssetID);
       });
     });
   });
@@ -714,49 +724,49 @@ contract('TimedVote', () => {
   describe('Interface', () => {
     describe('#approve', () => {
       it('Fail without commitment', async() => {
-        await timedVote._addProposal(proposalID);
+        await timedVote._addProposal(proposalID, platformAssetID);
         await rejects(timedVote.approve(proposalID, {from: user1}));
       });
 
       it('Fail with locked commitment', async() => {
-        await timedVote._setCommitment(user1, 5);
-        await timedVote._addProposal(proposalID);
+        await timedVote._setCommitment(user1, platformAssetID, 5);
+        await timedVote._addProposal(proposalID, platformAssetID);
         await rejects(timedVote.approve(proposalID, {from: user1}));
       });
 
       it('Fail with missing proposal', async() => {
-        await timedVote._setCommitment(user1, 5);
+        await timedVote._setCommitment(user1, platformAssetID, 5);
         await timedVote._timeTravelDays(unlockDays);
         await rejects(timedVote.approve(proposalID, {from: user1}));
       });
 
       it('Fail with closed proposal', async() => {
-        await timedVote._setCommitment(user1, 5);
+        await timedVote._setCommitment(user1, platformAssetID, 5);
         await timedVote._timeTravelDays(unlockDays);
-        await timedVote._addProposal(proposalID);
+        await timedVote._addProposal(proposalID, platformAssetID);
         await timedVote._timeTravelDays(closeDays);
         await rejects(timedVote.approve(proposalID, {from: user1}));
       });
 
       it('Fail on plural vote', async() => {
-        await timedVote._setCommitment(user1, 5);
+        await timedVote._setCommitment(user1, platformAssetID, 5);
         await timedVote._timeTravelDays(unlockDays);
-        await timedVote._addProposal(proposalID);
+        await timedVote._addProposal(proposalID, platformAssetID);
         await timedVote._setVoter(proposalID, user1);
         await rejects(timedVote.approve(proposalID, {from: user1}));
       });
 
       it('Succeed', async() => {
-        await timedVote._setCommitment(user1, 5);
+        await timedVote._setCommitment(user1, platformAssetID, 5);
         await timedVote._timeTravelDays(unlockDays);
-        await timedVote._addProposal(proposalID);
+        await timedVote._addProposal(proposalID, platformAssetID);
         await timedVote.approve(proposalID, {from: user1});
       });
 
       it('Emit Approve', async() => {
-        await timedVote._setCommitment(user1, 5);
+        await timedVote._setCommitment(user1, platformAssetID, 5);
         await timedVote._timeTravelDays(unlockDays);
-        await timedVote._addProposal(proposalID);
+        await timedVote._addProposal(proposalID, platformAssetID);
         const { logs: events } = await timedVote.approve(
           proposalID,
           {from: user1}
@@ -772,43 +782,43 @@ contract('TimedVote', () => {
 
     describe('#commit', () => {
       it('Fail with value 0', async() => {
-        await rejects(timedVote.commit(0, {from: user1}));
+        await rejects(timedVote.commit(0, platformAssetID, {from: user1}));
       });
 
       it('Fail without approval', async() => {
-        await rejects(timedVote.commit(5, {from: user1}));
+        await rejects(timedVote.commit(5, platformAssetID, {from: user1}));
       });
 
       it('Fail with insufficient approval', async() => {
         await token.transfer(user1, 100);
         await token.approve(timedVote.address, 5, {from: user1});
-        await rejects(timedVote.commit(100, {from: user1}));
+        await rejects(timedVote.commit(100, platformAssetID, {from: user1}));
       });
 
       it('Fail on transfer failure', async() => {
         await token.transfer(user1, 100);
         await token.approve(timedVote.address, 100, {from: user1});
         await token._failNextTransferFrom();
-        await rejects(timedVote.commit(100, {from: user1}));
+        await rejects(timedVote.commit(100, platformAssetID, {from: user1}));
       });
 
       it('Succeed', async() => {
         await token.transfer(user1, 100);
         await token.approve(timedVote.address, 100, {from: user1});
-        await timedVote.commit(100, {from: user1});
+        await timedVote.commit(100, platformAssetID, {from: user1});
       });
 
       it('Fail double commit', async() => {
         await token.transfer(user1, 200);
         await token.approve(timedVote.address, 200, {from: user1});
-        await timedVote.commit(100, {from: user1});
-        await rejects(timedVote.commit(100, {from: user1}));
+        await timedVote.commit(100, platformAssetID, {from: user1});
+        await rejects(timedVote.commit(100, platformAssetID, {from: user1}));
       });
 
       it('Emit Commit', async() => {
         await token.transfer(user1, 100);
         await token.approve(timedVote.address, 100, {from: user1});
-        const { logs: events } = await timedVote.commit(100, {from: user1});
+        const { logs: events } = await timedVote.commit(100, platformAssetID, {from: user1});
         assert.isAtLeast(events.length, 1);
         const event = events.pop();
         assert.strictEqual(event.event, 'Commit');
@@ -819,49 +829,49 @@ contract('TimedVote', () => {
 
     describe('#decline', () => {
       it('Fail without commitment', async() => {
-        await timedVote._addProposal(proposalID);
+        await timedVote._addProposal(proposalID, platformAssetID);
         await rejects(timedVote.decline(proposalID, {from: user1}));
       });
 
       it('Fail with locked commitment', async() => {
-        await timedVote._setCommitment(user1, 5);
-        await timedVote._addProposal(proposalID);
+        await timedVote._setCommitment(user1, platformAssetID, 5);
+        await timedVote._addProposal(proposalID, platformAssetID);
         await rejects(timedVote.decline(proposalID, {from: user1}));
       });
 
       it('Fail with missing proposal', async() => {
-        await timedVote._setCommitment(user1, 5);
+        await timedVote._setCommitment(user1, platformAssetID, 5);
         await timedVote._timeTravelDays(unlockDays);
         await rejects(timedVote.decline(proposalID, {from: user1}));
       });
 
       it('Fail with closed proposal', async() => {
-        await timedVote._setCommitment(user1, 5);
+        await timedVote._setCommitment(user1, platformAssetID, 5);
         await timedVote._timeTravelDays(unlockDays);
-        await timedVote._addProposal(proposalID);
+        await timedVote._addProposal(proposalID, platformAssetID);
         await timedVote._timeTravelDays(closeDays);
         await rejects(timedVote.decline(proposalID, {from: user1}));
       });
 
       it('Fail on plural vote', async() => {
-        await timedVote._setCommitment(user1, 5);
+        await timedVote._setCommitment(user1, platformAssetID, 5);
         await timedVote._timeTravelDays(unlockDays);
-        await timedVote._addProposal(proposalID);
+        await timedVote._addProposal(proposalID, platformAssetID);
         await timedVote._setVoter(proposalID, user1);
         await rejects(timedVote.decline(proposalID, {from: user1}));
       });
 
       it('Succeed', async() => {
-        await timedVote._setCommitment(user1, 5);
+        await timedVote._setCommitment(user1, platformAssetID, 5);
         await timedVote._timeTravelDays(unlockDays);
-        await timedVote._addProposal(proposalID);
+        await timedVote._addProposal(proposalID, platformAssetID);
         await timedVote.decline(proposalID, {from: user1});
       });
 
       it('Emit Decline', async() => {
-        await timedVote._setCommitment(user1, 5);
+        await timedVote._setCommitment(user1, platformAssetID, 5);
         await timedVote._timeTravelDays(unlockDays);
-        await timedVote._addProposal(proposalID);
+        await timedVote._addProposal(proposalID, platformAssetID);
         const { logs: events } = await timedVote.decline(
           proposalID,
           {from: user1}
@@ -877,26 +887,27 @@ contract('TimedVote', () => {
 
     describe('#propose', () => {
       it('Fail without voting body', async() => {
-        await rejects(timedVote.propose(proposalID, {from: user1}));
+        await rejects(timedVote.propose(proposalID, platformAssetID, {from: user1}));
       });
 
       it('Fail with extant ID', async() => {
-        await timedVote._setBody(10);
-        await timedVote._addProposal(proposalID);
-        await rejects(timedVote.propose(proposalID, {from: user1}));
+        await timedVote._setBody(platformAssetID, 10);
+        await timedVote._addProposal(proposalID, platformAssetID);
+        await rejects(timedVote.propose(proposalID, platformAssetID, {from: user1}));
       });
 
       it('Succeed', async() => {
-        await timedVote._setBody(10);
-        await timedVote.propose(proposalID, {from: user1});
+        await timedVote._setBody(platformAssetID, 10);
+        await timedVote.propose(proposalID, platformAssetID, {from: user1});
         const extant = await timedVote.proposalExtant(proposalID);
         assert.isTrue(extant);
       });
 
       it('Emit Propose', async() => {
-        await timedVote._setBody(10);
+        await timedVote._setBody(platformAssetID, 10);
         const { logs: events } = await timedVote.propose(
           proposalID,
+          platformAssetID,
           {from: user1}
         );
         const event = events.pop();
@@ -912,15 +923,15 @@ contract('TimedVote', () => {
       });
 
       it('Fail with open proposal', async() => {
-        await timedVote._addProposal(proposalID);
+        await timedVote._addProposal(proposalID, platformAssetID);
         await rejects(timedVote.result(proposalID));
       });
 
       it('Defeated under quorum', async() => {
-        await timedVote._setBody(10000);
-        await timedVote._setCommitment(user1, 10);
+        await timedVote._setBody(platformAssetID, 10000);
+        await timedVote._setCommitment(user1, platformAssetID, 10);
         await timedVote._timeTravelDays(unlockDays);
-        await timedVote._addProposal(proposalID);
+        await timedVote._addProposal(proposalID, platformAssetID);
         await timedVote.approve(proposalID, {from: user1});
         await timedVote._timeTravelDays(closeDays);
         const result = await timedVote.result(proposalID);
@@ -928,10 +939,10 @@ contract('TimedVote', () => {
       });
 
       it('Defeated under threshold', async() => {
-        await timedVote._setCommitment(user1, tokenSupply / 4);
-        await timedVote._setCommitment(user2, tokenSupply / 4);
+        await timedVote._setCommitment(user1, platformAssetID, tokenSupply / 4);
+        await timedVote._setCommitment(user2, platformAssetID, tokenSupply / 4);
         await timedVote._timeTravelDays(unlockDays);
-        await timedVote._addProposal(proposalID);
+        await timedVote._addProposal(proposalID, platformAssetID);
         await timedVote.approve(proposalID, {from: user1});
         await timedVote.decline(proposalID, {from: user2});
         await timedVote._timeTravelDays(closeDays);
@@ -940,10 +951,10 @@ contract('TimedVote', () => {
       });
 
       it('Passed', async() => {
-        await timedVote._setCommitment(user1, tokenSupply / 2);
-        await timedVote._setCommitment(user2, tokenSupply / 4);
+        await timedVote._setCommitment(user1, platformAssetID, tokenSupply / 2);
+        await timedVote._setCommitment(user2, platformAssetID, tokenSupply / 4);
         await timedVote._timeTravelDays(unlockDays);
-        await timedVote._addProposal(proposalID);
+        await timedVote._addProposal(proposalID, platformAssetID);
         await timedVote.approve(proposalID, {from: user1});
         await timedVote.decline(proposalID, {from: user2});
         await timedVote._timeTravelDays(closeDays);
@@ -958,8 +969,8 @@ contract('TimedVote', () => {
       });
 
       it('Initial', async() => {
-        await timedVote._setBody(10);
-        await timedVote._addProposal(proposalID);
+        await timedVote._setBody(platformAssetID, 10);
+        await timedVote._addProposal(proposalID, platformAssetID);
         const [ open, age, votingBody, voted, approval, dissent ] =
           await timedVote.status(proposalID);
         assert.isTrue(open);
@@ -971,25 +982,25 @@ contract('TimedVote', () => {
       });
 
       it('Closed', async() => {
-        await timedVote._setBody(10);
-        await timedVote._addProposal(proposalID);
+        await timedVote._setBody(platformAssetID, 10);
+        await timedVote._addProposal(proposalID, platformAssetID);
         await timedVote._timeTravelDays(closeDays);
         const [ open ] = await timedVote.status(proposalID);
         assert.isFalse(open);
       });
 
       it('Aged', async() => {
-        await timedVote._setBody(10);
-        await timedVote._addProposal(proposalID);
+        await timedVote._setBody(platformAssetID, 10);
+        await timedVote._addProposal(proposalID, platformAssetID);
         await timedVote._timeTravelSeconds(222);
         const [ , age ] = await timedVote.status(proposalID);
         assert.isTrue(BigNumber(age).isEqualTo(222));
       });
 
       it('Approval', async() => {
-        await timedVote._setCommitment(user1, 5);
+        await timedVote._setCommitment(user1, platformAssetID, 5);
         await timedVote._timeTravelDays(unlockDays);
-        await timedVote._addProposal(proposalID);
+        await timedVote._addProposal(proposalID, platformAssetID);
         await timedVote.approve(proposalID, {from: user1});
         const [ , , , voted, approval ] = await timedVote.status(proposalID);
         assert.isTrue(BigNumber(voted).isEqualTo(5));
@@ -997,9 +1008,9 @@ contract('TimedVote', () => {
       });
 
       it('Dissent', async() => {
-        await timedVote._setCommitment(user1, 5);
+        await timedVote._setCommitment(user1, platformAssetID, 5);
         await timedVote._timeTravelDays(unlockDays);
-        await timedVote._addProposal(proposalID);
+        await timedVote._addProposal(proposalID, platformAssetID);
         await timedVote.decline(proposalID, {from: user1});
         const [ , , , voted, , dissent ] = await timedVote.status(proposalID);
         assert.isTrue(BigNumber(voted).isEqualTo(5));
@@ -1007,10 +1018,10 @@ contract('TimedVote', () => {
       });
 
       it('Mixed', async() => {
-        await timedVote._setCommitment(user1, 5);
-        await timedVote._setCommitment(user2, 5);
+        await timedVote._setCommitment(user1, platformAssetID, 5);
+        await timedVote._setCommitment(user2, platformAssetID, 5);
         await timedVote._timeTravelDays(unlockDays);
-        await timedVote._addProposal(proposalID);
+        await timedVote._addProposal(proposalID, platformAssetID);
         await timedVote.approve(proposalID, {from: user1});
         await timedVote.decline(proposalID, {from: user2});
         const [ , , , voted, approval, dissent ] =
@@ -1023,39 +1034,39 @@ contract('TimedVote', () => {
 
     describe('#withdraw', () => {
       it('Fail without commitment', async() => {
-        await rejects(timedVote.withdraw({from: user1}));
+        await rejects(timedVote.withdraw(platformAssetID, {from: user1}));
       });
 
       it('Fail with locked commitment', async() => {
         await token.transfer(user1, 100);
         await token.approve(timedVote.address, 100, {from: user1});
-        await timedVote.commit(100, {from: user1});
-        await rejects(timedVote.withdraw({from: user1}));
+        await timedVote.commit(100, platformAssetID, {from: user1});
+        await rejects(timedVote.withdraw(platformAssetID, {from: user1}));
       });
 
       it('Fail on transfer failure', async() => {
         await token.transfer(user1, 100);
         await token.approve(timedVote.address, 100, {from: user1});
-        await timedVote.commit(100, {from: user1});
+        await timedVote.commit(100, platformAssetID, {from: user1});
         await timedVote._timeTravelDays(unlockDays);
         await token._failNextTransfer();
-        await rejects(timedVote.withdraw({from: user1}));
+        await rejects(timedVote.withdraw(platformAssetID, {from: user1}));
       });
 
       it('Succeed', async() => {
         await token.transfer(user1, 100);
         await token.approve(timedVote.address, 100, {from: user1});
-        await timedVote.commit(100, {from: user1});
+        await timedVote.commit(100, platformAssetID, {from: user1});
         await timedVote._timeTravelDays(unlockDays);
-        await timedVote.withdraw({from: user1});
+        await timedVote.withdraw(platformAssetID, {from: user1});
       });
 
       it('Emit Withdraw', async() => {
         await token.transfer(user1, 100);
         await token.approve(timedVote.address, 100, {from: user1});
-        await timedVote.commit(100, {from: user1});
+        await timedVote.commit(100, platformAssetID, {from: user1});
         await timedVote._timeTravelDays(unlockDays);
-        const { logs: events } = await timedVote.withdraw({from: user1});
+        const { logs: events } = await timedVote.withdraw(platformAssetID, {from: user1});
         assert.isAtLeast(events.length, 1);
         const event = events.pop();
         assert.strictEqual(event.event, 'Withdraw');


### PR DESCRIPTION
Changes to AssetGoverance and TimedVote for more generalized use across the platform. Additionally, I added the notion of the platform asset id. So any voting that uses the platform token must now reference the asset id associated with it.